### PR TITLE
chore: migrate k8s configs from submodule to monorepo

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -19,7 +19,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -58,14 +58,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Update deployment image tag
-        env:
-          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          git clone https://x-access-token:${DEPLOY_TOKEN}@github.com/igait-niu/igait-kubernetes-configs.git /tmp/k8s-configs
-          cd /tmp/k8s-configs
-          sed -i "s|image: ghcr.io/igait-niu/igait/igait-backend:.*|image: ghcr.io/igait-niu/igait/igait-backend:sha-${SHA_SHORT}|" igait-backend/deployment.yaml
+          sed -i "s|image: ghcr.io/igait-niu/igait/igait-backend:.*|image: ghcr.io/igait-niu/igait/igait-backend:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add igait-kubernetes-configs/
           git diff --cached --quiet || git commit -m "deploy: igait-backend:sha-${SHA_SHORT}" && git push

--- a/.github/workflows/build-stage1.yml
+++ b/.github/workflows/build-stage1.yml
@@ -19,7 +19,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -58,14 +58,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Update deployment image tag
-        env:
-          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          git clone https://x-access-token:${DEPLOY_TOKEN}@github.com/igait-niu/igait-kubernetes-configs.git /tmp/k8s-configs
-          cd /tmp/k8s-configs
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage1-media-conversion:.*|value: ghcr.io/igait-niu/igait/igait-stage1-media-conversion:sha-${SHA_SHORT}|" igait-backend/deployment.yaml
+          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage1-media-conversion:.*|value: ghcr.io/igait-niu/igait/igait-stage1-media-conversion:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add igait-kubernetes-configs/
           git diff --cached --quiet || git commit -m "deploy: igait-stage1-media-conversion:sha-${SHA_SHORT}" && git push

--- a/.github/workflows/build-stage2.yml
+++ b/.github/workflows/build-stage2.yml
@@ -19,7 +19,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -60,14 +60,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Update deployment image tag
-        env:
-          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          git clone https://x-access-token:${DEPLOY_TOKEN}@github.com/igait-niu/igait-kubernetes-configs.git /tmp/k8s-configs
-          cd /tmp/k8s-configs
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage2-validity-check:.*|value: ghcr.io/igait-niu/igait/igait-stage2-validity-check:sha-${SHA_SHORT}|" igait-backend/deployment.yaml
+          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage2-validity-check:.*|value: ghcr.io/igait-niu/igait/igait-stage2-validity-check:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add igait-kubernetes-configs/
           git diff --cached --quiet || git commit -m "deploy: igait-stage2-validity-check:sha-${SHA_SHORT}" && git push

--- a/.github/workflows/build-stage3.yml
+++ b/.github/workflows/build-stage3.yml
@@ -19,7 +19,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -58,14 +58,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Update deployment image tag
-        env:
-          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          git clone https://x-access-token:${DEPLOY_TOKEN}@github.com/igait-niu/igait-kubernetes-configs.git /tmp/k8s-configs
-          cd /tmp/k8s-configs
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage3-reframing:.*|value: ghcr.io/igait-niu/igait/igait-stage3-reframing:sha-${SHA_SHORT}|" igait-backend/deployment.yaml
+          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage3-reframing:.*|value: ghcr.io/igait-niu/igait/igait-stage3-reframing:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add igait-kubernetes-configs/
           git diff --cached --quiet || git commit -m "deploy: igait-stage3-reframing:sha-${SHA_SHORT}" && git push

--- a/.github/workflows/build-stage4.yml
+++ b/.github/workflows/build-stage4.yml
@@ -19,7 +19,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -60,14 +60,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Update deployment image tag
-        env:
-          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          git clone https://x-access-token:${DEPLOY_TOKEN}@github.com/igait-niu/igait-kubernetes-configs.git /tmp/k8s-configs
-          cd /tmp/k8s-configs
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage4-pose-estimation:.*|value: ghcr.io/igait-niu/igait/igait-stage4-pose-estimation:sha-${SHA_SHORT}|" igait-backend/deployment.yaml
+          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage4-pose-estimation:.*|value: ghcr.io/igait-niu/igait/igait-stage4-pose-estimation:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add igait-kubernetes-configs/
           git diff --cached --quiet || git commit -m "deploy: igait-stage4-pose-estimation:sha-${SHA_SHORT}" && git push

--- a/.github/workflows/build-stage5.yml
+++ b/.github/workflows/build-stage5.yml
@@ -19,7 +19,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -60,14 +60,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Update deployment image tag
-        env:
-          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          git clone https://x-access-token:${DEPLOY_TOKEN}@github.com/igait-niu/igait-kubernetes-configs.git /tmp/k8s-configs
-          cd /tmp/k8s-configs
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage5-cycle-detection:.*|value: ghcr.io/igait-niu/igait/igait-stage5-cycle-detection:sha-${SHA_SHORT}|" igait-backend/deployment.yaml
+          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage5-cycle-detection:.*|value: ghcr.io/igait-niu/igait/igait-stage5-cycle-detection:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add igait-kubernetes-configs/
           git diff --cached --quiet || git commit -m "deploy: igait-stage5-cycle-detection:sha-${SHA_SHORT}" && git push

--- a/.github/workflows/build-stage6.yml
+++ b/.github/workflows/build-stage6.yml
@@ -19,7 +19,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -60,14 +60,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Update deployment image tag
-        env:
-          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          git clone https://x-access-token:${DEPLOY_TOKEN}@github.com/igait-niu/igait-kubernetes-configs.git /tmp/k8s-configs
-          cd /tmp/k8s-configs
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage6-prediction:.*|value: ghcr.io/igait-niu/igait/igait-stage6-prediction:sha-${SHA_SHORT}|" igait-backend/deployment.yaml
+          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage6-prediction:.*|value: ghcr.io/igait-niu/igait/igait-stage6-prediction:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add igait-kubernetes-configs/
           git diff --cached --quiet || git commit -m "deploy: igait-stage6-prediction:sha-${SHA_SHORT}" && git push

--- a/.github/workflows/build-stage7.yml
+++ b/.github/workflows/build-stage7.yml
@@ -19,7 +19,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -58,14 +58,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Update deployment image tag
-        env:
-          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          git clone https://x-access-token:${DEPLOY_TOKEN}@github.com/igait-niu/igait-kubernetes-configs.git /tmp/k8s-configs
-          cd /tmp/k8s-configs
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage7-finalize:.*|value: ghcr.io/igait-niu/igait/igait-stage7-finalize:sha-${SHA_SHORT}|" igait-backend/deployment.yaml
+          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage7-finalize:.*|value: ghcr.io/igait-niu/igait/igait-stage7-finalize:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add igait-kubernetes-configs/
           git diff --cached --quiet || git commit -m "deploy: igait-stage7-finalize:sha-${SHA_SHORT}" && git push

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -16,7 +16,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-24.04-arm
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -66,14 +66,10 @@ jobs:
             VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}
 
       - name: Update deployment image tag
-        env:
-          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          git clone https://x-access-token:${DEPLOY_TOKEN}@github.com/igait-niu/igait-kubernetes-configs.git /tmp/k8s-configs
-          cd /tmp/k8s-configs
-          sed -i "s|image: ghcr.io/igait-niu/igait/igait-frontend:.*|image: ghcr.io/igait-niu/igait/igait-frontend:sha-${SHA_SHORT}|" igait-frontend/deployment.yaml
+          sed -i "s|image: ghcr.io/igait-niu/igait/igait-frontend:.*|image: ghcr.io/igait-niu/igait/igait-frontend:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-frontend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git add igait-kubernetes-configs/
           git diff --cached --quiet || git commit -m "deploy: igait-frontend:sha-${SHA_SHORT}" && git push

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,3 @@
 	path = igait-stages/igait-stage6-prediction/iGAIT_MODEL_IO
 	url = https://github.com/igait-niu/iGAIT_MODEL_IO
 
-[submodule "igait-kubernetes-configs"]
-	path = igait-kubernetes-configs
-	url = https://github.com/igait-niu/igait-kubernetes-configs

--- a/igait-kubernetes-configs/.gitignore
+++ b/igait-kubernetes-configs/.gitignore
@@ -1,0 +1,3 @@
+*/secrets.yaml
+*/secret.yaml
+*/gcp-key-secret.yaml

--- a/igait-kubernetes-configs/README.md
+++ b/igait-kubernetes-configs/README.md
@@ -1,0 +1,1 @@
+# igait-kubernetes-configs

--- a/igait-kubernetes-configs/argocd/apps/app-of-apps.yaml
+++ b/igait-kubernetes-configs/argocd/apps/app-of-apps.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-of-apps
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igait-niu/igait.git
+    targetRevision: master
+    path: igait-kubernetes-configs/argocd/apps
+    directory:
+      recurse: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/igait-kubernetes-configs/argocd/apps/cloudflared.yaml
+++ b/igait-kubernetes-configs/argocd/apps/cloudflared.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cloudflared
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igait-niu/igait.git
+    targetRevision: master
+    path: igait-kubernetes-configs/cloudflared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: igait
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/igait-kubernetes-configs/argocd/apps/igait.yaml
+++ b/igait-kubernetes-configs/argocd/apps/igait.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: igait
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igait-niu/igait.git
+    targetRevision: master
+    path: igait-kubernetes-configs
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: igait
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/igait-kubernetes-configs/argocd/apps/nvidia-device-plugin.yaml
+++ b/igait-kubernetes-configs/argocd/apps/nvidia-device-plugin.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nvidia-device-plugin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://nvidia.github.io/k8s-device-plugin
+    chart: nvidia-device-plugin
+    targetRevision: 0.17.1
+    helm:
+      valueFiles: []
+      values: |
+        nodeSelector: {}
+        affinity: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: nvidia-device-plugin
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/igait-kubernetes-configs/cloudflared/deployment.yaml
+++ b/igait-kubernetes-configs/cloudflared/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared
+  namespace: igait
+  labels:
+    app: cloudflared
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      pod: cloudflared
+  template:
+    metadata:
+      labels:
+        pod: cloudflared
+    spec:
+      securityContext:
+        sysctls:
+        # Allows ICMP traffic (ping, traceroute) to resources behind cloudflared.
+          - name: net.ipv4.ping_group_range
+            value: "65532 65532"
+      containers:
+        - image: cloudflare/cloudflared:latest
+          name: cloudflared
+          env:
+            # Defines an environment variable for the tunnel token.
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflared
+                  key: CF_TUNNEL_TOKEN
+          command:
+            # Configures tunnel run parameters
+            - cloudflared
+            - tunnel
+            - --no-autoupdate
+            - --protocol
+            - http2
+            - --loglevel
+            - debug
+            - --metrics
+            - 0.0.0.0:2000
+            - run
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          #livenessProbe:
+          #  httpGet:
+              # Cloudflared has a /ready endpoint which returns 200 if and only if
+              # it has an active connection to Cloudflare's network.
+          #    path: /ready
+          #    port: 2000
+          #  failureThreshold: 1
+          #  initialDelaySeconds: 10
+          #  periodSeconds: 10

--- a/igait-kubernetes-configs/igait-backend/deployment.yaml
+++ b/igait-kubernetes-configs/igait-backend/deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: igait-backend
+  namespace: igait
+  labels:
+    app: igait-backend
+spec:
+  revisionHistoryLimit: 1
+  replicas: 2
+  selector:
+    matchLabels:
+      app: igait-backend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: igait-backend
+    spec:
+      serviceAccountName: igait-backend
+      containers:
+      - image: ghcr.io/igait-niu/igait/igait-backend:sha-f5357a5
+        name: igait-backend
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+        env:
+        - name: PORT
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: PORT
+        - name: RUST_LOG
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: RUST_LOG
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: GOOGLE_APPLICATION_CREDENTIALS
+        - name: FIREBASE_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: FIREBASE_ACCESS_KEY
+        - name: FIREBASE_RTDB_URL
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: FIREBASE_RTDB_URL
+        - name: AWS_S3_BUCKET
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: AWS_S3_BUCKET
+        - name: AWS_REGION
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: AWS_REGION
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: AWS_SECRET_ACCESS_KEY
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: OPENAI_API_KEY
+        - name: OPENAI_ASSISTANT_ID
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: OPENAI_ASSISTANT_ID
+        - name: OPENAI_VECTOR_STORE_ID
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: OPENAI_VECTOR_STORE_ID
+        # Pipeline orchestrator
+        - name: ENABLE_ORCHESTRATOR
+          value: "true"
+        # Stage container images (updated by CI/CD)
+        - name: STAGE1_IMAGE
+          value: ghcr.io/igait-niu/igait/igait-stage1-media-conversion:sha-7a7b157
+        - name: STAGE2_IMAGE
+          value: ghcr.io/igait-niu/igait/igait-stage2-validity-check:sha-7a7b157
+        - name: STAGE3_IMAGE
+          value: ghcr.io/igait-niu/igait/igait-stage3-reframing:sha-7a7b157
+        - name: STAGE4_IMAGE
+          value: ghcr.io/igait-niu/igait/igait-stage4-pose-estimation:sha-7a7b157
+        - name: STAGE5_IMAGE
+          value: ghcr.io/igait-niu/igait/igait-stage5-cycle-detection:sha-7a7b157
+        - name: STAGE6_IMAGE
+          value: ghcr.io/igait-niu/igait/igait-stage6-prediction:sha-7a7b157
+        - name: STAGE7_IMAGE
+          value: ghcr.io/igait-niu/igait/igait-stage7-finalize:sha-7a7b157
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+            ephemeral-storage: 256Mi
+          requests:
+            cpu: 250m
+            memory: 512Mi
+            ephemeral-storage: 64Mi
+        volumeMounts:
+        - name: gcp-key
+          mountPath: /credentials
+          readOnly: true
+      volumes:
+      - name: gcp-key
+        secret:
+          secretName: gcp-key

--- a/igait-kubernetes-configs/igait-backend/rbac.yaml
+++ b/igait-kubernetes-configs/igait-backend/rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: igait-backend
+  namespace: igait
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: igait-job-manager
+  namespace: igait
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create", "get", "list", "watch", "delete"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: igait-backend-job-manager
+  namespace: igait
+subjects:
+- kind: ServiceAccount
+  name: igait-backend
+  namespace: igait
+roleRef:
+  kind: Role
+  name: igait-job-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/igait-kubernetes-configs/igait-backend/service.yaml
+++ b/igait-kubernetes-configs/igait-backend/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: igait-backend
+  namespace: igait
+  labels:
+    app: igait-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: igait-backend
+  ports:
+  - port: 3000
+    targetPort: 3000
+    protocol: TCP

--- a/igait-kubernetes-configs/igait-frontend/deployment.yaml
+++ b/igait-kubernetes-configs/igait-frontend/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: igait-frontend
+  namespace: igait
+  labels:
+    app: igait-frontend
+spec:
+  revisionHistoryLimit: 1
+  replicas: 2
+  selector:
+    matchLabels:
+      app: igait-frontend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: igait-frontend
+    spec:
+      containers:
+      - image: ghcr.io/igait-niu/igait/igait-frontend:sha-f5357a5
+        name: igait-frontend
+        ports:
+        - containerPort: 4173
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 750m
+            memory: 2Gi
+            ephemeral-storage: 128Mi
+          requests:
+            cpu: 250m
+            memory: 512Mi
+            ephemeral-storage: 32Mi
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 4173
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 4173
+          initialDelaySeconds: 10
+          periodSeconds: 30

--- a/igait-kubernetes-configs/igait-frontend/service.yaml
+++ b/igait-kubernetes-configs/igait-frontend/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: igait-frontend
+  namespace: igait
+  labels:
+    app: igait-frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: igait-frontend
+  ports:
+  - port: 80
+    targetPort: 4173
+    protocol: TCP

--- a/igait-kubernetes-configs/igait-namespace/namespace.yaml
+++ b/igait-kubernetes-configs/igait-namespace/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: igait

--- a/igait-kubernetes-configs/kustomization.yaml
+++ b/igait-kubernetes-configs/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - igait-namespace/namespace.yaml
+  - igait-frontend/deployment.yaml
+  - igait-frontend/service.yaml
+  - igait-backend/rbac.yaml
+  - igait-backend/deployment.yaml
+  - igait-backend/service.yaml


### PR DESCRIPTION
## Summary

- **Absorbs `igait-kubernetes-configs`** from a git submodule into the monorepo as regular files
- **Simplifies CI deploy steps**: workflows now `sed` the deployment YAML in-place and push, instead of cloning a separate repo via `DEPLOY_TOKEN`
- **Updates ArgoCD Application manifests** to point at `igait-niu/igait.git` with `igait-kubernetes-configs/` path prefix (and `targetRevision: master`)

## What changes

| Area | Before | After |
|------|--------|-------|
| K8s configs | Separate repo (`igait-niu/igait-kubernetes-configs`) as git submodule | Regular directory in monorepo |
| CI deploy step | `git clone` separate repo → `sed` → `git push` (needs `DEPLOY_TOKEN`) | `sed` in-place → `git push` (uses `GITHUB_TOKEN` via `contents: write`) |
| ArgoCD source | `igait-kubernetes-configs.git` @ `main` | `igait.git` @ `master`, path `igait-kubernetes-configs/` |

## Post-merge steps

After merging, the following manual steps are needed:

1. **Update ArgoCD on the cluster** — SSH into `ai-leads` and update the app-of-apps bootstrap to point to the monorepo:
   ```bash
   ssh root@ai-leads
   kubectl apply -f <updated-app-of-apps.yaml>  # or argocd app set ...
   ```
2. **Delete the old repo** — `igait-niu/igait-kubernetes-configs` can be archived/deleted
3. **Remove `DEPLOY_TOKEN` secret** — no longer needed in the repo's Actions secrets

## Test plan

- [ ] Verify ArgoCD syncs correctly after updating the source repo/path
- [ ] Trigger a CI build and verify the deploy step updates the image tag in-place
- [ ] Confirm the old `igait-kubernetes-configs` repo is no longer referenced anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)