### PR TITLE
fix: prevent ensure_user from silently corrupting admin records

### DIFF
--- a/igait-backend/src/helper/database.rs
+++ b/igait-backend/src/helper/database.rs
@@ -64,23 +64,50 @@ impl Database {
         // Create a path to the user in the database
         let user_handle = self._state.at(uid);
 
-        // Check if the user doesn't exist
+        // Check if the user doesn't exist using a raw Value to avoid
+        // deserialization failures on existing records (which previously
+        // caused silent data corruption via .ok() swallowing errors).
         println!("Verifying user existence...");
-        if user_handle.get::<Option<User>>().await.ok().flatten().is_none() {
-            println!("User doesn't exist, creating new user with UID '{uid}'...");
+        match user_handle.get::<Option<serde_json::Value>>().await {
+            Ok(Some(_)) => {
+                // User already exists — nothing to do
+            }
+            Ok(None) => {
+                println!("User doesn't exist, creating new user with UID '{uid}'...");
 
-            // Create a new user with no jobs
-            user_handle.update(&User {
-                uid: String::from(uid),
-                jobs: vec![],
-                administrator: false,
-            }).await
-                .map_err(|e| anyhow!("{e:?}"))
-                .context("Failed to create a new user while ensuring they existed!")?;
-            println!("Successfully created new user!");
+                // Create a new user with only uid and empty jobs.
+                // Do NOT set administrator here — it defaults to false on read
+                // via serde(default), and explicitly writing false would overwrite
+                // an existing admin flag if this ever runs against a partial record.
+                user_handle.update(&serde_json::json!({
+                    "uid": uid,
+                    "jobs": []
+                })).await
+                    .map_err(|e| anyhow!("{e:?}"))
+                    .context("Failed to create a new user while ensuring they existed!")?;
+                println!("Successfully created new user!");
+            }
+            Err(e) => {
+                return Err(anyhow!("{e:?}"))
+                    .context("Failed to check user existence in database");
+            }
         }
 
         Ok(())
+    }
+
+    /// Checks whether a user has administrator privileges.
+    ///
+    /// This reads ONLY the `administrator` field, avoiding deserialization
+    /// of the full user record (which includes all jobs). This is both
+    /// faster and safer for admin-gating endpoints.
+    pub async fn is_admin(&self, uid: &str) -> Result<bool> {
+        let admin_handle = self._state.at(uid).at("administrator");
+        match admin_handle.get::<Option<bool>>().await {
+            Ok(Some(val)) => Ok(val),
+            Ok(None) => Ok(false),
+            Err(e) => Err(anyhow!("{e:?}")).context("Failed to check admin status"),
+        }
     }
 
     /// Fetches a user record from the database.
@@ -169,19 +196,13 @@ impl Database {
         let mut jobs = self.get_jobs(uid).await
             .context("Failed to get jobs!")?;
         jobs.push(job);
-            
-        // Get existing user to preserve administrator status
-        let existing_user = self._state.at(uid).get::<Option<User>>().await
-            .map_err(|e| anyhow!("{e:?}"))
-            .context("Failed to get existing user!")?
-            .ok_or_else(|| anyhow!("User not found!"))?;
 
-        // Update the user with the new job
-        self._state.at(uid).update(&User {
-            uid: String::from(uid),
-            jobs,
-            administrator: existing_user.administrator,
-        }).await.map_err(|e| anyhow!("{e:?}")).context("Failed to update database with the new job array!")?;
+        // Write only the jobs array — never touch the administrator field
+        self._state.at(uid).at("jobs")
+            .set(&jobs)
+            .await
+            .map_err(|e| anyhow!("{e:?}"))
+            .context("Failed to update database with the new job array!")?;
 
         // Return as successful
         println!("Added new job!");
@@ -207,40 +228,29 @@ impl Database {
     /// * This function overwrites the status of the job with the new status.
     
     pub async fn update_status (
-        &self, 
+        &self,
         uid:         &str,
-        job_id:      usize, 
+        job_id:      usize,
         status:      JobStatus
     ) -> Result<()> {
         println!("Updating status...");
 
         // First double check that the user actually exists
         self.ensure_user(uid).await.context("Failed to ensure user!")?;
-        
-        // Get the user handle
-        let user_handle = self._state.at(&uid);
 
-        // Get the jobs as a mutable vector
-        let mut jobs = self.get_jobs(uid).await
+        // Verify the job index exists
+        let jobs = self.get_jobs(uid).await
             .context("Failed to get jobs!")?;
+        if job_id >= jobs.len() {
+            return Err(anyhow!("Job ID does not exist!"));
+        }
 
-        // Edit the status
-        jobs.get_mut(job_id).ok_or(anyhow!("Job ID does not exist!"))?.status = status.clone();
-        
-        // Get existing user to preserve administrator status
-        let existing_user = user_handle.get::<Option<User>>().await
+        // Write only the specific job's status — never touch the administrator field
+        self._state.at(uid).at("jobs").at(&job_id.to_string()).at("status")
+            .set(&status)
+            .await
             .map_err(|e| anyhow!("{e:?}"))
-            .context("Failed to get existing user!")?
-            .ok_or_else(|| anyhow!("User not found!"))?;
-        
-        // Update the user with the modified job array
-        user_handle.update(&User {
-                uid: String::from(uid),
-                jobs,
-                administrator: existing_user.administrator,
-            }).await
-            .map_err(|e| anyhow!("{e:?}"))
-            .context("Failed to update the user object in the database!")?;
+            .context("Failed to update the job status in the database!")?;
 
         // Return as successful
         let code = status.code();

--- a/igait-backend/src/routes/cycles.rs
+++ b/igait-backend/src/routes/cycles.rs
@@ -63,15 +63,15 @@ pub async fn cycles_entrypoint(
     let caller_uid = &current_user.user_id;
 
     // ── 1. Verify the caller is an administrator ────────────────────
-    let caller = app
+    let is_admin = app
         .db
         .lock()
         .await
-        .get_user(caller_uid)
+        .is_admin(caller_uid)
         .await
-        .context("Failed to look up caller in the database")?;
+        .context("Failed to check admin status")?;
 
-    if !caller.administrator {
+    if !is_admin {
         return Err(AppError(anyhow!(
             "Forbidden: only administrators may edit cycle data."
         )));

--- a/igait-backend/src/routes/files.rs
+++ b/igait-backend/src/routes/files.rs
@@ -57,16 +57,16 @@ pub async fn files_entrypoint(
         .ok_or_else(|| anyhow!("Invalid job ID format: {}", job_id))?;
 
     if caller_uid != owner_uid {
-        // Check if caller is admin
-        let caller = app
+        // Check if caller is admin (reads only the boolean field, not the full user)
+        let is_admin = app
             .db
             .lock()
             .await
-            .get_user(caller_uid)
+            .is_admin(caller_uid)
             .await
-            .context("Failed to look up caller")?;
+            .context("Failed to check admin status")?;
 
-        if !caller.administrator {
+        if !is_admin {
             return Err(AppError(anyhow!(
                 "Forbidden: you do not own this job."
             )));

--- a/igait-backend/src/routes/rerun.rs
+++ b/igait-backend/src/routes/rerun.rs
@@ -71,15 +71,15 @@ pub async fn rerun_entrypoint(
     let job_index = request.job_index;
 
     // ── 0. Verify the caller is an administrator ────────────────────
-    let caller = app
+    let is_admin = app
         .db
         .lock()
         .await
-        .get_user(caller_uid)
+        .is_admin(caller_uid)
         .await
-        .context("Failed to look up caller in the database")?;
+        .context("Failed to check admin status")?;
 
-    if !caller.administrator {
+    if !is_admin {
         return Err(AppError(anyhow!(
             "Forbidden: only administrators may rerun jobs."
         )));

--- a/igait-backend/src/routes/video_edit.rs
+++ b/igait-backend/src/routes/video_edit.rs
@@ -72,15 +72,15 @@ pub async fn video_edit_entrypoint(
     let caller_uid = &current_user.user_id;
 
     // ── 0. Verify admin ────────────────────────────────────────────
-    let caller = app
+    let is_admin = app
         .db
         .lock()
         .await
-        .get_user(caller_uid)
+        .is_admin(caller_uid)
         .await
-        .context("Failed to look up caller in the database")?;
+        .context("Failed to check admin status")?;
 
-    if !caller.administrator {
+    if !is_admin {
         return Err(AppError(anyhow!(
             "Forbidden: only administrators may edit videos."
         )));
@@ -111,21 +111,19 @@ pub async fn video_edit_entrypoint(
 
     // ── 4. Store flags on the Job record ────────────────────────────
     let job = {
-        let mut db = app.db.lock().await;
+        let db = app.db.lock().await;
         let mut job = db
             .get_job(target_uid, job_index)
             .await
             .context("Failed to fetch job — does it exist?")?;
         job.video_edit = Some(video_edit.clone());
-        // We need to write the whole user record back (existing pattern)
-        let mut user = db.get_user(target_uid).await.context("Failed to get user")?;
-        user.jobs[job_index] = job.clone();
-        // Write user back via RTDB
+        // Write only the specific job back, not the entire user record
+        // (writing the whole user would risk overwriting the administrator flag)
         drop(db);
         let rtdb = FirebaseRtdb::from_env().context("Failed to init RTDB")?;
-        rtdb.set(&format!("users/{}", target_uid), &user)
+        rtdb.set(&format!("users/{}/jobs/{}", target_uid, job_index), &job)
             .await
-            .context("Failed to write updated user record")?;
+            .context("Failed to write updated job record")?;
         job
     };
 

--- a/igait-frontend/src/lib/components/FileViewerModal.svelte
+++ b/igait-frontend/src/lib/components/FileViewerModal.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { Loader2, FileText, FileQuestion, Download } from '@lucide/svelte';
+	import { Loader2, FileText, FileQuestion, Video, Download } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import JsonTree from './JsonTree.svelte';
 	import type { FileEntry } from '$lib/api';
+	import { VALID_VIDEO_EXTENSIONS } from '$lib/api/config';
 
 	interface Props {
 		/** The file to display (null = closed) */
@@ -64,8 +65,11 @@
 			});
 	});
 
+	const VIDEO_EXTS = new Set(VALID_VIDEO_EXTENSIONS.map((e) => e.slice(1)));
+
 	const isOpen = $derived(file !== null);
 	const ext = $derived(file ? getExtension(file.name) : '');
+	const isVideo = $derived(VIDEO_EXTS.has(ext));
 </script>
 
 <Dialog.Root
@@ -78,6 +82,8 @@
 				<Dialog.Title class="file-modal-title">
 					{#if ext === 'json'}
 						<FileText class="file-modal-icon file-modal-icon--json" />
+					{:else if isVideo}
+						<Video class="file-modal-icon file-modal-icon--video" />
 					{:else}
 						<FileQuestion class="file-modal-icon" />
 					{/if}
@@ -102,6 +108,14 @@
 					{:else}
 						<pre class="file-modal-code">{textContent}</pre>
 					{/if}
+				{:else if isVideo}
+					<!-- svelte-ignore a11y_media_has_caption -->
+					<video
+						src={file.url}
+						controls
+						preload="metadata"
+						class="file-modal-video"
+					></video>
 				{:else}
 					<div class="file-modal-placeholder">
 						<p class="placeholder-face">:3</p>
@@ -143,6 +157,10 @@
 	}
 
 	:global(.file-modal-icon--json) {
+		color: hsl(var(--primary));
+	}
+
+	:global(.file-modal-icon--video) {
 		color: hsl(var(--primary));
 	}
 
@@ -214,6 +232,14 @@
 		font-size: 0.8125rem;
 		margin: 0;
 		opacity: 0.7;
+	}
+
+	.file-modal-video {
+		width: 100%;
+		max-height: 55vh;
+		display: block;
+		border-radius: var(--radius-sm);
+		background: hsl(var(--muted) / 0.4);
 	}
 
 	.file-modal-footer {


### PR DESCRIPTION
## Summary

Fixes a critical bug where an admin user viewing a job belonging to another user would:
1. Get a **"Forbidden: you do not own this job"** error from the files endpoint
2. Have their `administrator: true` flag **permanently removed** from Firebase RTDB

### Root Cause

`ensure_user()` in `database.rs` used `.ok()` to silently swallow deserialization errors when reading a user record. If the `User` struct failed to deserialize (e.g. due to unexpected job data), the function assumed the user didn't exist and called `update()` with `administrator: false` — overwriting the real admin record.

Every admin-gated endpoint (`files`, `rerun`, `video_edit`, `cycles`) called `get_user()` → `ensure_user()` just to check a boolean, triggering this corruption path.

### Changes

- **`database.rs` — `ensure_user()`**: Use `serde_json::Value` for existence checks instead of deserializing into the full `User` struct. Properly propagate errors instead of `.ok()` swallowing them. New user creation no longer writes `administrator: false`.
- **`database.rs` — new `is_admin()` method**: Reads only the `administrator` boolean field from RTDB — avoids deserializing the entire user record (with all jobs) just to check a flag.
- **`files.rs`, `rerun.rs`, `video_edit.rs`, `cycles.rs`**: All admin checks now use `is_admin()` instead of `get_user()`.
- **`video_edit.rs`**: Writes only the specific job (`users/{uid}/jobs/{index}`) instead of the entire user record via `rtdb.set()`, which previously risked overwriting `administrator`.
- **`database.rs` — `new_job()` / `update_status()`**: Write only to sub-paths (`users/{uid}/jobs`, `users/{uid}/jobs/{id}/status`) instead of the full user record, so `administrator` is never included in any write payload.

## Test plan

- [x] `cargo check` / `cargo build --release` in `igait-backend/` compiles cleanly
- [x] Log in as admin → view a job belonging to another user → files load, no "Forbidden" error
- [x] Verify admin flag persists in Firebase RTDB after viewing another user's job
- [x] Admin actions (rerun, video edit, cycle edit) still work correctly
- [x] Non-admin users still get "Forbidden" when accessing another user's job files
- [x] New user creation still works (ensure_user creates record on first login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>