### PR TITLE
feat: binary ASD/NO-ASD output

### DIFF
--- a/igait-frontend/src/routes/(authenticated)/job/[id]/+page.svelte
+++ b/igait-frontend/src/routes/(authenticated)/job/[id]/+page.svelte
@@ -140,7 +140,8 @@
 	const stage1Files = $derived((filesData as JobFilesResponse | null)?.stages['stage_1'] ?? []);
 
 	const stage1FrontVideo = $derived(
-		stage1Files.find((f: FileEntry) => f.name.startsWith('front') && f.name.endsWith('.mp4')) ?? null
+		stage1Files.find((f: FileEntry) => f.name.startsWith('front') && f.name.endsWith('.mp4')) ??
+			null
 	);
 	const stage1SideVideo = $derived(
 		stage1Files.find((f: FileEntry) => f.name.startsWith('side') && f.name.endsWith('.mp4')) ?? null
@@ -151,7 +152,8 @@
 	const stage5Files = $derived((filesData as JobFilesResponse | null)?.stages['stage_5'] ?? []);
 
 	const frontVideoFile = $derived(
-		stage4Files.find((f: FileEntry) => f.name.startsWith('front') && f.name.endsWith('.mp4')) ?? null
+		stage4Files.find((f: FileEntry) => f.name.startsWith('front') && f.name.endsWith('.mp4')) ??
+			null
 	);
 	const sideVideoFile = $derived(
 		stage4Files.find((f: FileEntry) => f.name.startsWith('side') && f.name.endsWith('.mp4')) ?? null
@@ -178,9 +180,9 @@
 	function getStatusLabel(status: JobStatus): string {
 		switch (status.code) {
 			case 'Complete':
-				return status.asd ? 'ASD Detected' : 'No ASD';
+				return 'Analysis completed';
 			case 'Error':
-				return 'Error';
+				return 'Analysis failed';
 			case 'Processing':
 				return `Stage ${status.stage}/${status.num_stages}`;
 			case 'Submitted':
@@ -368,17 +370,11 @@
 							Results
 						</h4>
 						<div class="detail-row">
-							<span class="detail-label">ASD Detection</span>
-							<Badge variant={job.status.asd ? 'destructive' : 'default'} class="detail-badge">
-								{job.status.asd ? 'ASD Indicators Detected' : 'No ASD Indicators'}
-							</Badge>
-						</div>
-						<div class="detail-row">
-							<span class="detail-label">Confidence</span>
+							<span class="detail-label">Result</span>
 							<span class="detail-value">
 								{job.status.asd
-									? (job.status.prediction * 100).toFixed(1)
-									: ((1 - job.status.prediction) * 100).toFixed(1)}%
+									? 'Submitted videos show walking pattern more similar to autistic children than non-autistic children.'
+									: 'Submitted videos show walking pattern more similar to non-autistic children than autistic children.'}
 							</span>
 						</div>
 					</div>
@@ -396,7 +392,14 @@
 							<XCircle class="section-icon" />
 							Error
 						</h4>
-						<pre class="error-preview">{job.status.logs}</pre>
+						{#if isAdmin}
+							<pre class="error-preview">{job.status.logs}</pre>
+						{:else}
+							<p class="text-sm text-muted-foreground">
+								Something went wrong processing your submission. Please contact GaitStudy@niu.edu
+								for assistance.
+							</p>
+						{/if}
 					</div>
 				{/if}
 			</div>
@@ -445,7 +448,11 @@
 								<FileOutput class="sub-tab-icon" />
 								Output Files
 								{#if !filesLoading}
-									<Badge variant="outline" class="sub-tab-badge {outputFileCount === 0 ? 'sub-tab-badge-zero' : ''}">{outputFileCount}</Badge>
+									<Badge
+										variant="outline"
+										class="sub-tab-badge {outputFileCount === 0 ? 'sub-tab-badge-zero' : ''}"
+										>{outputFileCount}</Badge
+									>
 								{/if}
 							</button>
 							<button
@@ -455,7 +462,11 @@
 							>
 								<ScrollText class="sub-tab-icon" />
 								Logs
-								<Badge variant="outline" class="sub-tab-badge {logLineCount === 0 ? 'sub-tab-badge-zero' : ''}">{logLineCount}</Badge>
+								<Badge
+									variant="outline"
+									class="sub-tab-badge {logLineCount === 0 ? 'sub-tab-badge-zero' : ''}"
+									>{logLineCount}</Badge
+								>
 							</button>
 						</div>
 
@@ -466,7 +477,12 @@
 									Video Editor
 								</Button>
 							{:else}
-								<Button variant="outline" size="sm" disabled title="Stage 1 outputs must exist to use the Video Editor">
+								<Button
+									variant="outline"
+									size="sm"
+									disabled
+									title="Stage 1 outputs must exist to use the Video Editor"
+								>
 									<Film class="mr-1 h-4 w-4" />
 									Video Editor
 								</Button>
@@ -493,24 +509,24 @@
 
 					<!-- Tab Content -->
 					<div class="tab-content">
-					{#if activeSubTab === 'output'}
-						<FileViewer
-							files={outputFiles}
-							loading={filesLoading}
-							error={filesError}
-							label=""
-							stageNumber={activeStageNumber}
-							allFiles={filesData}
-							{isAdmin}
-							{jobId}
-						/>
-					{:else if activeSubTab === 'logs'}
-						<div class="logs-content">
-							{#if currentStageLogs}
-								<pre class="log-output">{currentStageLogs}</pre>
-							{/if}
-						</div>
-					{/if}
+						{#if activeSubTab === 'output'}
+							<FileViewer
+								files={outputFiles}
+								loading={filesLoading}
+								error={filesError}
+								label=""
+								stageNumber={activeStageNumber}
+								allFiles={filesData}
+								{isAdmin}
+								{jobId}
+							/>
+						{:else if activeSubTab === 'logs'}
+							<div class="logs-content">
+								{#if currentStageLogs}
+									<pre class="log-output">{currentStageLogs}</pre>
+								{/if}
+							</div>
+						{/if}
 					</div>
 				{:else}
 					<div class="stage-not-started">
@@ -1096,7 +1112,11 @@
 	}
 
 	@keyframes spin {
-		from { transform: rotate(0deg); }
-		to { transform: rotate(360deg); }
+		from {
+			transform: rotate(0deg);
+		}
+		to {
+			transform: rotate(360deg);
+		}
 	}
 </style>

--- a/igait-frontend/src/routes/(authenticated)/submissions/JobDetailsDialog.svelte
+++ b/igait-frontend/src/routes/(authenticated)/submissions/JobDetailsDialog.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog';
-	import * as Accordion from '$lib/components/ui/accordion';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Separator } from '$lib/components/ui/separator';
 	import { Button } from '$lib/components/ui/button';
@@ -12,9 +11,7 @@
 		XCircle,
 		User as UserIcon,
 		Calendar,
-		Download,
-		AlertTriangle,
-		ScrollText
+		AlertTriangle
 	} from '@lucide/svelte';
 	import type { Job } from '../../../types/Job';
 	import type { JobStatus } from '../../../types/JobStatus';
@@ -42,7 +39,7 @@
 	): 'default' | 'secondary' | 'destructive' | 'outline' {
 		switch (status.code) {
 			case 'Complete':
-				return status.asd ? 'destructive' : 'default';
+				return 'default';
 			case 'Error':
 				return 'destructive';
 			case 'Processing':
@@ -89,38 +86,6 @@
 		}
 		return null;
 	});
-
-	// Error logs
-	const errorLogs = $derived.by(() => {
-		if (job.status.code === 'Error') {
-			return job.status.logs;
-		}
-		return null;
-	});
-
-	// Stage logs - sorted entries from stage_logs HashMap
-	const STAGE_NAMES: Record<string, string> = {
-		stage_1: 'Media Conversion',
-		stage_2: 'Validity Check',
-		stage_3: 'Reframing',
-		stage_4: 'Pose Estimation',
-		stage_5: 'Cycle Detection',
-		stage_6: 'ML Prediction',
-		stage_7: 'Finalize'
-	};
-
-	const stageLogs = $derived.by(() => {
-		if (!job.stage_logs) return [];
-		return Object.entries(job.stage_logs)
-			.sort(([a], [b]) => a.localeCompare(b))
-			.map(([key, value]) => ({
-				key,
-				label: STAGE_NAMES[key] ?? key,
-				stageNum: key.replace('stage_', ''),
-				logs: value
-			}));
-	});
-	const hasStageLogs = $derived(stageLogs.length > 0);
 </script>
 
 <Dialog.Root open={true} onOpenChange={onClose}>
@@ -221,74 +186,31 @@
 				<div class="space-y-3">
 					<h3 class="flex items-center gap-2 text-sm font-medium">
 						<CheckCircle2 class="h-4 w-4" />
-						Analysis Results
+						Results
 					</h3>
-					<div class="grid gap-3 text-sm">
-						<div class="flex items-center justify-between rounded-lg bg-muted p-3">
-							<span class="text-muted-foreground">ASD Detection:</span>
-							<Badge variant={completeResult.asd ? 'destructive' : 'default'}>
-								{completeResult.asd ? 'ASD Indicators Detected' : 'No ASD Indicators'}
-							</Badge>
-						</div>
-						<div class="flex items-center justify-between rounded-lg bg-muted p-3">
-							<span class="text-muted-foreground">Confidence:</span>
-							<span class="font-medium">
-								{completeResult.asd
-									? (completeResult.prediction * 100).toFixed(1)
-									: ((1 - completeResult.prediction) * 100).toFixed(1)}%
-							</span>
-						</div>
+					<div class="rounded-lg bg-muted p-3 text-sm">
+						{completeResult.asd
+							? 'Submitted videos show walking pattern more similar to autistic children than non-autistic children.'
+							: 'Submitted videos show walking pattern more similar to non-autistic children than autistic children.'}
 					</div>
-					<Button class="w-full" size="sm">
-						<Download class="mr-2 h-4 w-4" />
-						Download Full Report
-					</Button>
 				</div>
 			{/if}
 
-			{#if isError && errorLogs}
+			{#if isError}
 				<Separator />
 
-				<!-- Error Section -->
+				<!-- Error Section (user-friendly) -->
 				<div class="space-y-3">
 					<h3 class="flex items-center gap-2 text-sm font-medium text-destructive">
 						<AlertTriangle class="h-4 w-4" />
-						Error Details
+						Analysis Failed
 					</h3>
-					<div class="rounded-lg border border-destructive/20 bg-destructive/10 p-3">
-						<pre
-							class="max-h-32 overflow-y-auto text-xs break-words whitespace-pre-wrap text-destructive">{errorLogs}</pre>
+					<div
+						class="rounded-lg border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive"
+					>
+						Something went wrong processing your submission. Please contact GaitStudy@niu.edu for
+						assistance.
 					</div>
-				</div>
-			{/if}
-
-			{#if hasStageLogs}
-				<Separator />
-
-				<!-- Stage Logs Section -->
-				<div class="space-y-3">
-					<h3 class="flex items-center gap-2 text-sm font-medium">
-						<ScrollText class="h-4 w-4" />
-						Stage Logs
-					</h3>
-					<Accordion.Root type="multiple">
-						{#each stageLogs as { key, label, stageNum, logs } (key)}
-							<Accordion.Item value={key}>
-								<Accordion.Trigger class="text-sm">
-									<span class="flex items-center gap-2">
-										<Badge variant="outline" class="px-1.5 font-mono text-xs">{stageNum}</Badge>
-										{label}
-									</span>
-								</Accordion.Trigger>
-								<Accordion.Content>
-									<div class="rounded-lg bg-muted p-3">
-										<pre
-											class="max-h-48 overflow-y-auto font-mono text-xs break-words whitespace-pre-wrap">{logs}</pre>
-									</div>
-								</Accordion.Content>
-							</Accordion.Item>
-						{/each}
-					</Accordion.Root>
 				</div>
 			{/if}
 		</div>

--- a/igait-lib/src/microservice/backend_status.rs
+++ b/igait-lib/src/microservice/backend_status.rs
@@ -91,23 +91,17 @@ impl JobStatus {
 
     /// Create a new Complete status with prediction results
     pub fn complete(prediction: f32, asd: bool) -> Self {
-        let value = if asd {
-            format!("Analysis complete - ASD indicators detected ({:.1}% confidence)", prediction * 100.0)
-        } else {
-            format!("Analysis complete - No ASD indicators ({:.1}% confidence)", (1.0 - prediction) * 100.0)
-        };
-        
         Self::Complete {
             prediction,
             asd,
-            value,
+            value: "Analysis completed".to_string(),
         }
     }
 
     /// Create a new Error status with logs
     pub fn error(logs: String) -> Self {
         Self::Error {
-            value: "Analysis failed - see logs for details".to_string(),
+            value: "Analysis failed".to_string(),
             logs,
         }
     }

--- a/igait-lib/src/microservice/email.rs
+++ b/igait-lib/src/microservice/email.rs
@@ -156,12 +156,11 @@ impl EmailTemplates {
         (subject, body)
     }
 
-    /// Builds a success email with the prediction score.
+    /// Builds a success email with the binary ASD/no-ASD result.
     ///
     /// Sent when the pipeline completes successfully with a prediction.
     pub fn prediction_success(
         datetime: &str,
-        score: f64,
         is_asd: bool,
         age: Option<i16>,
         ethnicity: Option<&str>,
@@ -172,15 +171,18 @@ impl EmailTemplates {
         job_id: &str,
     ) -> (String, String) {
         let subject = "Your recent submission to iGait App has completed!".to_string();
-        
+
         let result_text = if is_asd {
-            "Our analysis indicates markers consistent with ASD gait patterns."
+            "Submitted videos show walking pattern more similar to autistic children \
+             than non-autistic children."
         } else {
-            "Our analysis indicates typical gait patterns."
+            "Submitted videos show walking pattern more similar to non-autistic children \
+             than autistic children."
         };
-        
+
         let body = format!(
-            "We determined a likelihood score of {:.2} for your submission on {}!<br><br>\
+            "Dear iGAIT user,<br><br>\
+             Your submission on {} has been processed!<br><br>\
              {}<br><br>\
              Submission information:<br>\
              Age: {}<br>\
@@ -191,7 +193,6 @@ impl EmailTemplates {
              User ID: {}<br>\
              Job ID: {}<br><br>\
              If you have questions about your results, please contact GaitStudy@niu.edu.",
-            score,
             datetime,
             result_text,
             age.map(|a| a.to_string()).unwrap_or_else(|| "N/A".to_string()),

--- a/igait-stages/igait-stage7-finalize/src/main.rs
+++ b/igait-stages/igait-stage7-finalize/src/main.rs
@@ -33,8 +33,6 @@ struct PredictionResult {
     error_message: Option<String>,
 }
 
-/// ASD threshold - scores >= this value indicate ASD markers.
-const ASD_THRESHOLD: f64 = 0.5;
 
 /// The finalize worker handles the final stage of the pipeline.
 pub struct FinalizeStageWorker {
@@ -65,12 +63,12 @@ impl FinalizeStageWorker {
 
     /// Attempts to read prediction.json from S3 for a given job.
     ///
-    /// Parses the full ensemble result and computes the score by averaging
-    /// the individual model probabilities. Returns `Some(score)` if found
-    /// and valid, `None` otherwise.
-    async fn get_prediction_score(&self, job_id: &str) -> Option<f64> {
+    /// Parses the ensemble result and returns the binary `class` field
+    /// (1 = ASD, 0 = no ASD). Returns `Some(is_asd)` if found and valid,
+    /// `None` otherwise.
+    async fn get_prediction_class(&self, job_id: &str) -> Option<bool> {
         let prediction_path = format!("jobs/{}/stage_6/prediction.json", job_id);
-        
+
         match self.storage.download(&prediction_path).await {
             Ok(data) => {
                 match serde_json::from_slice::<PredictionResult>(&data) {
@@ -88,28 +86,20 @@ impl FinalizeStageWorker {
                             return None;
                         }
 
-                        // Average the probabilities from all ensemble models
-                        if let Some(ref probs) = result.probabilities {
-                            if probs.is_empty() {
-                                eprintln!("Empty probabilities array for {}", job_id);
-                                return None;
+                        // Use the ensemble's binary classification directly
+                        match result.class {
+                            Some(class) => {
+                                let is_asd = class == 1;
+                                println!(
+                                    "Prediction for {}: class={}, is_asd={}",
+                                    job_id, class, is_asd
+                                );
+                                Some(is_asd)
                             }
-                            let score = probs.iter().sum::<f64>() / probs.len() as f64;
-                            println!(
-                                "Computed score for {} by averaging {} probabilities: {:.4}",
-                                job_id,
-                                probs.len(),
-                                score
-                            );
-                            Some(score)
-                        } else {
-                            // Fallback: use class value (0 or 1) as score
-                            let score = result.class.unwrap_or(0) as f64;
-                            println!(
-                                "No probabilities for {}, using class as score: {}",
-                                job_id, score
-                            );
-                            Some(score)
+                            None => {
+                                eprintln!("No class field in prediction.json for {}", job_id);
+                                None
+                            }
                         }
                     }
                     Err(e) => {
@@ -129,20 +119,17 @@ impl FinalizeStageWorker {
     async fn send_success_email(
         &self,
         job: &FinalizeQueueItem,
-        score: f64,
+        is_asd: bool,
         logs: &mut String,
     ) -> Result<()> {
         let email = job.metadata.email.as_deref()
             .ok_or_else(|| anyhow::anyhow!("No email address in job metadata"))?;
-        
+
         let dt_now_utc: DateTime<Utc> = SystemTime::now().into();
         let dt_now_cst = dt_now_utc.with_timezone(&chrono_tz::US::Central);
-        
-        let is_asd = score >= ASD_THRESHOLD;
-        
+
         let (subject, body) = EmailTemplates::prediction_success(
             &dt_now_cst.to_string(),
-            score,
             is_asd,
             job.metadata.age,
             job.metadata.ethnicity.as_deref(),
@@ -154,11 +141,11 @@ impl FinalizeStageWorker {
         );
 
         logs.push_str(&format!("Sending success email to {}\n", email));
-        logs.push_str(&format!("Score: {:.2}, ASD indicator: {}\n", score, is_asd));
-        
+        logs.push_str(&format!("ASD indicator: {}\n", is_asd));
+
         self.email_client.send(email, &subject, &body).await?;
         logs.push_str("Success email sent\n");
-        
+
         Ok(())
     }
 
@@ -264,13 +251,13 @@ impl FinalizeWorker for FinalizeStageWorker {
         self.update_stage_status(&job.job_id, 7, StageStatus::Running).await;
 
         // Check for prediction.json in S3 - this is the source of truth
-        let prediction_score = self.get_prediction_score(&job.job_id).await;
+        let prediction_class = self.get_prediction_class(&job.job_id).await;
 
-        let result = if let Some(score) = prediction_score {
+        let result = if let Some(is_asd) = prediction_class {
             // Prediction file exists - this was a successful pipeline run
-            logs.push_str(&format!("Prediction found: score = {:.4}\n", score));
-            
-            match self.send_success_email(job, score, &mut logs).await {
+            logs.push_str(&format!("Prediction found: is_asd = {}\n", is_asd));
+
+            match self.send_success_email(job, is_asd, &mut logs).await {
                 Ok(_) => {
                     logs.push_str("Job completed successfully\n");
                 }
@@ -282,17 +269,17 @@ impl FinalizeWorker for FinalizeStageWorker {
             }
             
             // Update job status to Complete
-            let is_asd = score >= ASD_THRESHOLD;
-            self.update_job_status(&job.job_id, JobStatus::complete(score as f32, is_asd)).await;
+            // prediction field kept for backward compatibility; set to 1.0/0.0 matching class
+            let prediction = if is_asd { 1.0_f32 } else { 0.0_f32 };
+            self.update_job_status(&job.job_id, JobStatus::complete(prediction, is_asd)).await;
             self.update_stage_status(&job.job_id, 7, StageStatus::Complete).await;
 
             // Upload stage 7 logs to Firebase RTDB
             self.upload_stage_logs(&job.job_id, &logs).await;
-            
+
             ProcessingResult::Success {
                 output_keys: HashMap::from([
-                    ("score".to_string(), score.to_string()),
-                    ("is_asd".to_string(), (score >= ASD_THRESHOLD).to_string()),
+                    ("is_asd".to_string(), is_asd.to_string()),
                 ]),
                 logs,
                 duration_ms: start_time.elapsed().as_millis() as u64,


### PR DESCRIPTION
## Summary

Closes #51

- **Use model's binary `class` field directly** instead of averaging `probabilities` — fixes incorrect ASD classification when ensemble vote disagrees with probability average
- **Remove confidence scores** from job status text, success email, and all frontend views (admin + user)
- **Hide internal details from regular users**: raw error logs show a friendly contact message instead; stage tabs were already admin-gated
- **Update email wording** to use the approved phrasing: "Submitted videos show walking pattern more similar to autistic/non-autistic children..."

### Files changed

| Layer | File | Change |
|-------|------|--------|
| Shared lib | `igait-lib/.../backend_status.rs` | Status value → "Analysis completed" / "Analysis failed" |
| Shared lib | `igait-lib/.../email.rs` | Removed `score` param, binary result text |
| Stage 7 | `igait-stages/.../main.rs` | `get_prediction_score()` → `get_prediction_class()`, uses `class` directly |
| Frontend | `job/[id]/+page.svelte` | Removed confidence row, binary result text, admin-gated error logs |
| Frontend | `JobDetailsDialog.svelte` | Removed confidence, stage logs, raw errors; binary result text |

## Test plan

- [ ] Submit a test video through the full pipeline and verify stage 7 reads `class` correctly
- [ ] Verify completed job page shows binary result text (not confidence %) for both admin and non-admin users
- [ ] Verify non-admin users cannot see stage tabs, stage logs, or raw error details
- [ ] Verify success email contains the new wording without any likelihood score
- [ ] Verify existing completed jobs still render correctly (backward compat — `prediction` field kept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)