### PR TITLE
chore: deploy Vaultwarden for team credential management

### DIFF
--- a/igait-kubernetes-configs/argocd/apps/vaultwarden.yaml
+++ b/igait-kubernetes-configs/argocd/apps/vaultwarden.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vaultwarden
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igait-niu/igait.git
+    targetRevision: master
+    path: igait-kubernetes-configs/vaultwarden
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: igait
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/igait-kubernetes-configs/vaultwarden/deployment.yaml
+++ b/igait-kubernetes-configs/vaultwarden/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vaultwarden
+  namespace: igait
+  labels:
+    app: vaultwarden
+spec:
+  revisionHistoryLimit: 1
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vaultwarden
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: vaultwarden
+    spec:
+      containers:
+      - image: vaultwarden/server:1.33.2
+        name: vaultwarden
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        env:
+        - name: DOMAIN
+          value: "https://vault.igaitapp.com"
+        - name: SIGNUPS_ALLOWED
+          value: "false"
+        - name: INVITATIONS_ALLOWED
+          value: "true"
+        - name: ADMIN_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: vaultwarden
+              key: ADMIN_TOKEN
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+            ephemeral-storage: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+            ephemeral-storage: 32Mi
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: vaultwarden-data

--- a/igait-kubernetes-configs/vaultwarden/pvc.yaml
+++ b/igait-kubernetes-configs/vaultwarden/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vaultwarden-data
+  namespace: igait
+  labels:
+    app: vaultwarden
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/igait-kubernetes-configs/vaultwarden/service.yaml
+++ b/igait-kubernetes-configs/vaultwarden/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vaultwarden
+  namespace: igait
+  labels:
+    app: vaultwarden
+spec:
+  selector:
+    app: vaultwarden
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP


### PR DESCRIPTION
## Summary

Adds a self-hosted Vaultwarden (Bitwarden-compatible) instance to the iGait Kubernetes cluster for secure team credential sharing.

- PVC-backed SQLite storage (1Gi)
- Signups disabled, invite-only via admin panel
- Admin token stored in pre-created K8s secret
- Own ArgoCD app (same pattern as cloudflared)
- Pinned to `vaultwarden/server:1.33.2`

### Pre-merge setup (already done)
- [x] Created `vaultwarden` secret with Argon2-hashed admin token
- [x] Added Cloudflare Tunnel route: `vault.igaitapp.com` → `http://vaultwarden.igait.svc:80`

### Post-merge
- [ ] Verify ArgoCD syncs the new app
- [ ] Visit `https://vault.igaitapp.com/admin` and confirm login
- [ ] Create "iGait" organization and invite team members

🤖 Generated with [Claude Code](https://claude.com/claude-code)