### PR TITLE
chore: add SES SMTP to Vaultwarden

### DIFF
--- a/igait-kubernetes-configs/vaultwarden/deployment.yaml
+++ b/igait-kubernetes-configs/vaultwarden/deployment.yaml
@@ -36,6 +36,27 @@ spec:
             secretKeyRef:
               name: vaultwarden
               key: ADMIN_TOKEN
+        # SMTP via AWS SES for invite emails
+        - name: SMTP_HOST
+          value: "email-smtp.us-east-2.amazonaws.com"
+        - name: SMTP_PORT
+          value: "587"
+        - name: SMTP_SECURITY
+          value: "starttls"
+        - name: SMTP_FROM
+          value: "noreply@igaitapp.com"
+        - name: SMTP_FROM_NAME
+          value: "iGait Vault"
+        - name: SMTP_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: vaultwarden
+              key: SMTP_USERNAME
+        - name: SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: vaultwarden
+              key: SMTP_PASSWORD
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
## Summary

Adds AWS SES SMTP configuration to the Vaultwarden deployment so invite emails actually send.

SMTP credentials are read from the `vaultwarden` K8s secret (`SMTP_USERNAME`, `SMTP_PASSWORD`).

### Pre-merge
- [x] Generate SES SMTP credentials (AWS Console → SES → SMTP Settings)
- [x] Recreate the secret with SMTP creds:
  ```bash
  kubectl delete secret vaultwarden -n igait
  kubectl create secret generic vaultwarden -n igait \
    --from-literal=ADMIN_TOKEN='<argon2 hash>' \
    --from-literal=SMTP_USERNAME='<ses smtp username>' \
    --from-literal=SMTP_PASSWORD='<ses smtp password>'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)