### PR TITLE
chore: bump Vaultwarden 1.33.2 → 1.35.3

### DIFF
--- a/igait-kubernetes-configs/vaultwarden/deployment.yaml
+++ b/igait-kubernetes-configs/vaultwarden/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: vaultwarden
     spec:
       containers:
-      - image: vaultwarden/server:1.33.2
+      - image: vaultwarden/server:1.35.3
         name: vaultwarden
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Summary

Bumps Vaultwarden from 1.33.2 to 1.35.3 to fix browser extension login failures.

**Problem**: The Bitwarden browser extension expects `accountKeysResponseModel` in the API response, which 1.33.2 doesn't provide — causing `"can't access property 'toWrappedAccountCryptographicState'"` on login. Web UI worked fine since it bundles an older client.

**Also includes**: Security fix for [GHSA-h265-g7rm-h337](https://github.com/dani-garcia/vaultwarden/security/advisories/GHSA-h265-g7rm-h337) (org collection access control bypass).

## Test plan

- [ ] Verify browser extension login works after ArgoCD sync
- [ ] Verify web UI still works at `vault.igaitapp.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)