### PR TITLE
feat: use UUID keys for job storage

### DIFF
--- a/igait-backend/Cargo.toml
+++ b/igait-backend/Cargo.toml
@@ -38,4 +38,5 @@ rand = "0.8"
 time-util = { version = "0.3", features = ["chrono", "serde"] }
 tokio-tungstenite = "0.24"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
+uuid = { version = "1", features = ["v4"] }
 ts-rs = "12.0.1"

--- a/igait-backend/src/helper/database.rs
+++ b/igait-backend/src/helper/database.rs
@@ -2,6 +2,7 @@ use crate::helper::lib::User;
 
 use firebase_rs::*;
 use anyhow::{ Context, Result, anyhow };
+use uuid::Uuid;
 
 use super::lib::{Job, JobStatus};
 
@@ -78,9 +79,9 @@ impl Database {
         Ok(jobs)
     }
 
-    /// Returns the next available job index for a user by finding the
-    /// highest existing numeric key and adding 1.
-    async fn next_job_index(&self, uid: &str) -> Result<usize> {
+    /// Returns the number of jobs a user has by counting keys in the
+    /// RTDB jobs object.
+    async fn job_count(&self, uid: &str) -> Result<usize> {
         let raw = match self._state.at(uid).at("jobs").get::<serde_json::Value>().await {
             Ok(v) => v,
             Err(e) if is_not_found(&e) => return Ok(0),
@@ -93,17 +94,12 @@ impl Database {
             None => return Ok(0),
         };
 
-        let max_index = obj.keys()
-            .filter_map(|k| k.parse::<usize>().ok())
-            .max();
-
-        Ok(max_index.map(|m| m + 1).unwrap_or(0))
+        Ok(obj.len())
     }
 
-    /// Checks whether a specific job index exists in Firebase RTDB
-    /// without deserializing the entire jobs array.
-    async fn job_exists(&self, uid: &str, job_id: usize) -> Result<bool> {
-        match self._state.at(uid).at("jobs").at(&job_id.to_string()).get::<serde_json::Value>().await {
+    /// Checks whether a specific job key exists in Firebase RTDB.
+    async fn job_exists(&self, uid: &str, job_id: &str) -> Result<bool> {
+        match self._state.at(uid).at("jobs").at(job_id).get::<serde_json::Value>().await {
             Ok(v) => Ok(!v.is_null()),
             Err(e) if is_not_found(&e) => Ok(false),
             Err(e) => Err(anyhow!("{e:?}"))
@@ -230,8 +226,7 @@ impl Database {
         // First double check that the user actually exists
         self.ensure_user(uid).await.context("Failed to ensure user!")?;
 
-        // Next index == total count of jobs so far
-        self.next_job_index(uid).await
+        self.job_count(uid).await
             .context("Failed to count jobs!")
     }
 
@@ -256,24 +251,22 @@ impl Database {
         &self,
         uid:         &str,
         job:         Job
-    ) -> Result<()> {
+    ) -> Result<String> {
         // First double check that the user actually exists
         self.ensure_user(uid).await.context("Failed to ensure user!")?;
 
-        // Find the next available index
-        let next_index = self.next_job_index(uid).await
-            .context("Failed to determine next job index!")?;
+        // Generate a unique key for this job
+        let job_key = Uuid::new_v4().to_string();
 
-        // Write the new job at the next index — never rewrite the whole array
-        self._state.at(uid).at("jobs").at(&next_index.to_string())
+        // Write the new job at the generated key
+        self._state.at(uid).at("jobs").at(&job_key)
             .update(&job)
             .await
             .map_err(|e| anyhow!("{e:?}"))
             .context("Failed to write new job to database!")?;
 
-        // Return as successful
-        println!("Added new job!");
-        Ok(())
+        println!("Added new job with key '{job_key}'!");
+        Ok(job_key)
     }
 
     /// Updates the status of a job.
@@ -297,7 +290,7 @@ impl Database {
     pub async fn update_status (
         &self,
         uid:         &str,
-        job_id:      usize,
+        job_key:     &str,
         status:      JobStatus
     ) -> Result<()> {
         println!("Updating status...");
@@ -305,13 +298,13 @@ impl Database {
         // First double check that the user actually exists
         self.ensure_user(uid).await.context("Failed to ensure user!")?;
 
-        // Verify the job index exists without deserializing the entire array
-        if !self.job_exists(uid, job_id).await? {
-            return Err(anyhow!("Job ID {} does not exist!", job_id));
+        // Verify the job key exists
+        if !self.job_exists(uid, job_key).await? {
+            return Err(anyhow!("Job key '{}' does not exist!", job_key));
         }
 
         // Write only the specific job's status — never touch the administrator field
-        self._state.at(uid).at("jobs").at(&job_id.to_string()).at("status")
+        self._state.at(uid).at("jobs").at(job_key).at("status")
             .update(&status)
             .await
             .map_err(|e| anyhow!("{e:?}"))
@@ -343,7 +336,7 @@ impl Database {
     pub async fn _get_status (
         &self,
         uid:         &str,
-        job_id:      usize
+        job_key:     &str
     ) -> Result<JobStatus> {
         println!("Getting status...");
 
@@ -351,11 +344,11 @@ impl Database {
         self.ensure_user(uid).await.context("Failed to ensure user!")?;
 
         // Read just this job's status directly
-        self._state.at(uid).at("jobs").at(&job_id.to_string()).at("status")
+        self._state.at(uid).at("jobs").at(job_key).at("status")
             .get::<JobStatus>()
             .await
             .map_err(|e| anyhow!("{e:?}"))
-            .context(format!("Failed to get status for job {}", job_id))
+            .context(format!("Failed to get status for job {}", job_key))
     }
 
     /// Gets a job given a user ID and a job ID.
@@ -377,7 +370,7 @@ impl Database {
     pub async fn get_job (
         &self,
         uid:         &str,
-        job_id:      usize
+        job_key:     &str
     ) -> Result<Job> {
         println!("Getting job...");
 
@@ -385,11 +378,11 @@ impl Database {
         self.ensure_user(uid).await.context("Failed to ensure user!")?;
 
         // Read just this specific job directly
-        self._state.at(uid).at("jobs").at(&job_id.to_string())
+        self._state.at(uid).at("jobs").at(job_key)
             .get::<Job>()
             .await
             .map_err(|e| anyhow!("{e:?}"))
-            .context(format!("Failed to get job {}", job_id))
+            .context(format!("Failed to get job {}", job_key))
     }
 
     /// Gets all jobs of a user.

--- a/igait-backend/src/helper/email.rs
+++ b/igait-backend/src/helper/email.rs
@@ -27,7 +27,7 @@ pub async fn send_welcome_email(
     app: Arc<AppState>,
     job: &Job,
     uid: &str,
-    job_id: usize,
+    job_key: &str,
 ) -> Result<()> {
     let dt_now_utc: DateTime<Utc> = SystemTime::now().into();
     let dt_now_cst = dt_now_utc.with_timezone(&chrono_tz::US::Central);
@@ -40,7 +40,7 @@ pub async fn send_welcome_email(
         &job.height,
         job.weight,
         uid,
-        &job_id.to_string(),
+        job_key,
     );
 
     send_email(app, &job.email, &subject, &body).await

--- a/igait-backend/src/routes/internal.rs
+++ b/igait-backend/src/routes/internal.rs
@@ -18,7 +18,7 @@ use crate::helper::{
 #[derive(Debug, Deserialize)]
 pub struct UpdateStatusRequest {
     pub user_id: String,
-    pub job_index: usize,
+    pub job_key: String,
     pub status: JobStatus,
 }
 
@@ -38,7 +38,7 @@ pub async fn update_status(
 ) -> Result<Json<UpdateStatusResponse>, AppError> {
     println!(
         "Received status update for user {} job {}: {:?}",
-        request.user_id, request.job_index, request.status.code()
+        request.user_id, request.job_key, request.status.code()
     );
 
     // Update the status in the database
@@ -46,7 +46,7 @@ pub async fn update_status(
         .db
         .lock()
         .await
-        .update_status(&request.user_id, request.job_index, request.status)
+        .update_status(&request.user_id, &request.job_key, request.status)
         .await
         .context("Failed to update job status")?;
 

--- a/igait-backend/src/routes/rerun.rs
+++ b/igait-backend/src/routes/rerun.rs
@@ -26,8 +26,8 @@ pub struct RerunRequest {
     /// The UID of the user who owns the job.
     /// Admins must specify this to indicate whose job to rerun.
     pub user_id: String,
-    /// The index of the job in the user's job list (0-indexed).
-    pub job_index: usize,
+    /// The key of the job in the user's job list.
+    pub job_key: String,
     /// The stage number to restart from (1–7).
     pub stage: u8,
 }
@@ -58,7 +58,7 @@ pub struct RerunResponse {
 /// # Arguments
 /// * `current_user` – The Firebase-authenticated user (extracted from Bearer token).
 /// * `app` – The shared application state.
-/// * `request` – JSON body with `user_id`, `job_index`, and `stage`.
+/// * `request` – JSON body with `user_id`, `job_key`, and `stage`.
 pub async fn rerun_entrypoint(
     current_user: FirebaseUser,
     State(app): State<AppStatePtr>,
@@ -68,7 +68,7 @@ pub async fn rerun_entrypoint(
     let caller_uid = &current_user.user_id;
     let target_uid = &request.user_id;
     let stage = request.stage;
-    let job_index = request.job_index;
+    let job_key = &request.job_key;
 
     // ── 0. Verify the caller is an administrator ────────────────────
     let is_admin = app
@@ -103,11 +103,11 @@ pub async fn rerun_entrypoint(
         .db
         .lock()
         .await
-        .get_job(target_uid, job_index)
+        .get_job(target_uid, job_key)
         .await
         .context("Failed to fetch the job — does it exist?")?;
 
-    let job_id = format!("{}_{}", target_uid, job_index);
+    let job_id = format!("{}_{}", target_uid, job_key);
     println!("Rerun requested by admin {}: job={}, stage={}", caller_uid, job_id, stage);
 
     // ── 3. Delete S3 outputs for stages `stage..=7` ─────────────────
@@ -127,7 +127,7 @@ pub async fn rerun_entrypoint(
     let rtdb_for_logs = FirebaseRtdb::from_env()
         .context("Failed to initialise Firebase RTDB client for log cleanup")?;
     for s in stage..=NUM_STAGES {
-        let log_path = format!("users/{}/jobs/{}/stage_logs/stage_{}", target_uid, job_index, s);
+        let log_path = format!("users/{}/jobs/{}/stage_logs/stage_{}", target_uid, job_key, s);
         rtdb_for_logs.delete(&log_path)
             .await
             .context(format!("Failed to delete logs for stage {}", s))?;
@@ -136,7 +136,7 @@ pub async fn rerun_entrypoint(
 
     // ── 3c. Reset stage statuses for stages `stage..=7` ────────────
     for s in stage..=NUM_STAGES {
-        let status_path = format!("users/{}/jobs/{}/stage_statuses/stage_{}", target_uid, job_index, s);
+        let status_path = format!("users/{}/jobs/{}/stage_statuses/stage_{}", target_uid, job_key, s);
         rtdb_for_logs.set(&status_path, &StageStatus::NotStarted)
             .await
             .context(format!("Failed to reset stage status for stage {}", s))?;
@@ -197,7 +197,7 @@ pub async fn rerun_entrypoint(
     app.db
         .lock()
         .await
-        .update_status(target_uid, job_index, status)
+        .update_status(target_uid, job_key, status)
         .await
         .context("Failed to update job status")?;
 

--- a/igait-backend/src/routes/upload.rs
+++ b/igait-backend/src/routes/upload.rs
@@ -225,19 +225,6 @@ pub async fn upload_entrypoint(
     // Build a new status object
     let mut status = JobStatus::submitted();
 
-    // Generate the new job ID (0-indexed)
-    let job_index = app
-        .db
-        .lock()
-        .await
-        .count_jobs(&uid)
-        .await
-        .context("Failed to count the number of jobs!")?;
-
-    // Build job ID string (format: "{user_id}_{job_index}")
-    let job_id = format!("{}_{}", uid, job_index);
-    println!("Created job ID: {}", job_id);
-
     // Build the new job object
     let job = Job {
         age:       arguments.age,
@@ -257,13 +244,17 @@ pub async fn upload_entrypoint(
         video_edit: None,
     };
 
-    // Add the job to the database
-    app.db
+    // Add the job to the database — returns the generated UUID key
+    let job_key = app.db
         .lock()
         .await
         .new_job(&uid, job.clone())
         .await
         .context("Failed to add the new job to the database!")?;
+
+    // Build job ID string (format: "{user_id}_{job_key}")
+    let job_id = format!("{}_{}", uid, job_key);
+    println!("Created job ID: {}", job_id);
 
     // Upload files to AWS S3 and dispatch to Stage 1
     if let Err(err) = upload_and_dispatch(
@@ -283,7 +274,7 @@ pub async fn upload_entrypoint(
         app.db
             .lock()
             .await
-            .update_status(&uid, job_index, status)
+            .update_status(&uid, &job_key, status)
             .await
             .context("Failed to update the status of the job!")?;
 
@@ -294,7 +285,7 @@ pub async fn upload_entrypoint(
     status = JobStatus::submitted();
 
     // Send the welcome email
-    send_welcome_email(app.clone(), &job, &uid, job_index)
+    send_welcome_email(app.clone(), &job, &uid, &job_key)
         .await
         .context("Failed to send welcome email!")?;
 
@@ -302,7 +293,7 @@ pub async fn upload_entrypoint(
     app.db
         .lock()
         .await
-        .update_status(&uid, job_index, status)
+        .update_status(&uid, &job_key, status)
         .await
         .context("Failed to update the status of the job!")?;
 

--- a/igait-backend/src/routes/video_edit.rs
+++ b/igait-backend/src/routes/video_edit.rs
@@ -86,14 +86,12 @@ pub async fn video_edit_entrypoint(
         )));
     }
 
-    // ── 1. Parse job_id → (user_id, job_index) ─────────────────────
+    // ── 1. Parse job_id → (user_id, job_key) ──────────────────────
     let last_underscore = job_id
         .rfind('_')
-        .ok_or_else(|| anyhow!("Invalid job_id format. Expected userId_jobIndex"))?;
+        .ok_or_else(|| anyhow!("Invalid job_id format. Expected userId_jobKey"))?;
     let target_uid = &job_id[..last_underscore];
-    let job_index: usize = job_id[last_underscore + 1..]
-        .parse()
-        .context("Invalid job index in job_id")?;
+    let job_key = &job_id[last_underscore + 1..];
 
     // ── 2. Validate request ─────────────────────────────────────────
     if let Some(ref front) = request.front {
@@ -113,7 +111,7 @@ pub async fn video_edit_entrypoint(
     let job = {
         let db = app.db.lock().await;
         let mut job = db
-            .get_job(target_uid, job_index)
+            .get_job(target_uid, job_key)
             .await
             .context("Failed to fetch job — does it exist?")?;
         job.video_edit = Some(video_edit.clone());
@@ -121,7 +119,7 @@ pub async fn video_edit_entrypoint(
         // (writing the whole user would risk overwriting the administrator flag)
         drop(db);
         let rtdb = FirebaseRtdb::from_env().context("Failed to init RTDB")?;
-        rtdb.set(&format!("users/{}/jobs/{}", target_uid, job_index), &job)
+        rtdb.set(&format!("users/{}/jobs/{}", target_uid, job_key), &job)
             .await
             .context("Failed to write updated job record")?;
         job
@@ -181,7 +179,7 @@ pub async fn video_edit_entrypoint(
     for s in 1..=NUM_STAGES {
         let log_path = format!(
             "users/{}/jobs/{}/stage_logs/stage_{}",
-            target_uid, job_index, s
+            target_uid, job_key, s
         );
         rtdb.delete(&log_path)
             .await
@@ -234,7 +232,7 @@ pub async fn video_edit_entrypoint(
     app.db
         .lock()
         .await
-        .update_status(target_uid, job_index, status)
+        .update_status(target_uid, job_key, status)
         .await
         .context("Failed to update job status")?;
 

--- a/igait-frontend/src/lib/api/client.ts
+++ b/igait-frontend/src/lib/api/client.ts
@@ -6,7 +6,14 @@
 import { type Result, Ok, Err, AppError, tryAsync } from '$lib/result';
 import { authStore } from '$lib/stores';
 import { API_ENDPOINTS, DEFAULT_TIMEOUT_MS } from './config';
-import type { RerunResponse, JobFilesResponse, UpdateCyclesResponse, GaitCycle, VideoEditRequest, VideoEditResponse } from './types';
+import type {
+	RerunResponse,
+	JobFilesResponse,
+	UpdateCyclesResponse,
+	GaitCycle,
+	VideoEditRequest,
+	VideoEditResponse
+} from './types';
 import type { ContributionRequest, ProgressCallback, ResearchContributionRequest } from './types';
 import { validateVideoFile, validateRequired, validateEmail } from './validation';
 
@@ -315,26 +322,19 @@ export async function rerunJob(
 
 	if (lastUnderscore === -1) {
 		return Err(
-			new AppError('Invalid job identifier format. Expected format: userId_jobIndex').withContext(
+			new AppError('Invalid job identifier format. Expected format: userId_jobKey').withContext(
 				'Failed to rerun job'
 			)
 		);
 	}
 
 	const userId = userIdJobIndex.slice(0, lastUnderscore);
-	const jobIndexStr = userIdJobIndex.slice(lastUnderscore + 1);
-	const jobIndex = parseInt(jobIndexStr, 10);
-
-	if (Number.isNaN(jobIndex) || jobIndex < 0) {
-		return Err(
-			new AppError('Invalid job index in job identifier').withContext('Failed to rerun job')
-		);
-	}
+	const jobKey = userIdJobIndex.slice(lastUnderscore + 1);
 
 	return authenticatedFetch<RerunResponse>(API_ENDPOINTS.rerun, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ user_id: userId, job_index: jobIndex, stage })
+		body: JSON.stringify({ user_id: userId, job_key: jobKey, stage })
 	});
 }
 
@@ -342,9 +342,7 @@ export async function rerunJob(
  * Fetch presigned download URLs for all files belonging to a job.
  * Returns files grouped by stage.
  */
-export async function getJobFiles(
-	jobId: string
-): Promise<Result<JobFilesResponse, AppError>> {
+export async function getJobFiles(jobId: string): Promise<Result<JobFilesResponse, AppError>> {
 	return authenticatedFetch<JobFilesResponse>(API_ENDPOINTS.files(jobId));
 }
 

--- a/igait-frontend/src/lib/hooks/admin.ts
+++ b/igait-frontend/src/lib/hooks/admin.ts
@@ -253,8 +253,8 @@ export async function approveQueueItem(
 	await set(queueRef, true);
 
 	// Also update user's job record
-	const jobIndex = parseInt(item.job_id.split('_').pop() ?? '0', 10);
-	const userJobRef = ref(db, `users/${item.user_id}/jobs/${jobIndex}/approved`);
+	const jobKey = item.job_id.slice(item.job_id.lastIndexOf('_') + 1);
+	const userJobRef = ref(db, `users/${item.user_id}/jobs/${jobKey}/approved`);
 	await set(userJobRef, true);
 }
 

--- a/igait-lib/src/microservice/worker.rs
+++ b/igait-lib/src/microservice/worker.rs
@@ -416,41 +416,38 @@ impl QueueOps {
     /// Updates the job status directly in Firebase RTDB.
     /// 
     /// This writes to `users/{user_id}/jobs/{job_index}/status`
-    pub async fn update_job_status(&self, user_id: &str, job_index: usize, status: &JobStatus) -> Result<()> {
-        let path = format!("users/{}/jobs/{}/status", user_id, job_index);
+    pub async fn update_job_status(&self, user_id: &str, job_key: &str, status: &JobStatus) -> Result<()> {
+        let path = format!("users/{}/jobs/{}/status", user_id, job_key);
         self.db.set(&path, status).await
     }
 
     /// Updates the per-stage status in Firebase RTDB.
     ///
-    /// This writes to `users/{user_id}/jobs/{job_index}/stage_statuses/stage_{n}`
-    pub async fn update_stage_status(&self, user_id: &str, job_index: usize, stage: u8, status: &StageStatus) -> Result<()> {
-        let path = format!("users/{}/jobs/{}/stage_statuses/stage_{}", user_id, job_index, stage);
+    /// This writes to `users/{user_id}/jobs/{job_key}/stage_statuses/stage_{n}`
+    pub async fn update_stage_status(&self, user_id: &str, job_key: &str, stage: u8, status: &StageStatus) -> Result<()> {
+        let path = format!("users/{}/jobs/{}/stage_statuses/stage_{}", user_id, job_key, stage);
         self.db.set(&path, status).await
     }
 
     /// Uploads stage logs to Firebase RTDB.
     ///
-    /// This writes to `users/{user_id}/jobs/{job_index}/stage_logs/stage_{n}`
-    pub async fn update_stage_logs(&self, user_id: &str, job_index: usize, stage: u8, logs: &str) -> Result<()> {
-        let path = format!("users/{}/jobs/{}/stage_logs/stage_{}", user_id, job_index, stage);
+    /// This writes to `users/{user_id}/jobs/{job_key}/stage_logs/stage_{n}`
+    pub async fn update_stage_logs(&self, user_id: &str, job_key: &str, stage: u8, logs: &str) -> Result<()> {
+        let path = format!("users/{}/jobs/{}/stage_logs/stage_{}", user_id, job_key, stage);
         self.db.set(&path, &logs).await
     }
 
-    /// Parses a job_id string into (user_id, job_index).
-    /// 
-    /// Job IDs are formatted as "{user_id}_{job_index}"
-    pub fn parse_job_id(job_id: &str) -> Result<(String, usize)> {
-        let parts: Vec<&str> = job_id.rsplitn(2, '_').collect();
-        if parts.len() != 2 {
-            anyhow::bail!("Invalid job_id format: {}", job_id);
-        }
-        
-        let job_index: usize = parts[0].parse()
-            .context("Failed to parse job index from job_id")?;
-        let user_id = parts[1].to_string();
-        
-        Ok((user_id, job_index))
+    /// Parses a job_id string into (user_id, job_key).
+    ///
+    /// Job IDs are formatted as "{user_id}_{job_key}"
+    pub fn parse_job_id(job_id: &str) -> Result<(String, String)> {
+        let last_underscore = job_id.rfind('_')
+            .ok_or_else(|| anyhow::anyhow!("Invalid job_id format: {}", job_id))?;
+
+        let user_id = job_id[..last_underscore].to_string();
+        let job_key = job_id[last_underscore + 1..].to_string();
+
+        Ok((user_id, job_key))
     }
 }
 
@@ -733,7 +730,7 @@ impl<W: StageWorker> WorkerRunner<W> {
     async fn upload_stage_logs(&self, job_id: &str, stage: u8, logs: &str) {
         match QueueOps::parse_job_id(job_id) {
             Ok((user_id, job_index)) => {
-                if let Err(e) = self.queue_ops.update_stage_logs(&user_id, job_index, stage, logs).await {
+                if let Err(e) = self.queue_ops.update_stage_logs(&user_id, &job_index, stage, logs).await {
                     eprintln!("Failed to upload stage {} logs to RTDB: {:?}", stage, e);
                 }
             }
@@ -747,7 +744,7 @@ impl<W: StageWorker> WorkerRunner<W> {
     async fn update_job_status(&self, job_id: &str, status: JobStatus) {
         match QueueOps::parse_job_id(job_id) {
             Ok((user_id, job_index)) => {
-                if let Err(e) = self.queue_ops.update_job_status(&user_id, job_index, &status).await {
+                if let Err(e) = self.queue_ops.update_job_status(&user_id, &job_index, &status).await {
                     eprintln!("Failed to update job status in RTDB: {:?}", e);
                 }
             }
@@ -761,7 +758,7 @@ impl<W: StageWorker> WorkerRunner<W> {
     async fn update_stage_status(&self, job_id: &str, stage: u8, status: StageStatus) {
         match QueueOps::parse_job_id(job_id) {
             Ok((user_id, job_index)) => {
-                if let Err(e) = self.queue_ops.update_stage_status(&user_id, job_index, stage, &status).await {
+                if let Err(e) = self.queue_ops.update_stage_status(&user_id, &job_index, stage, &status).await {
                     eprintln!("Failed to update stage {} status in RTDB: {:?}", stage, e);
                 }
             }
@@ -901,8 +898,8 @@ pub async fn run_stage_job<W: StageWorker>(worker: W) -> Result<()> {
 
     // Update job status to Processing
     if let Ok((user_id, job_index)) = QueueOps::parse_job_id(&job.job_id) {
-        let _ = queue_ops.update_job_status(&user_id, job_index, &JobStatus::processing(stage_num)).await;
-        let _ = queue_ops.update_stage_status(&user_id, job_index, stage_num, &StageStatus::Running).await;
+        let _ = queue_ops.update_job_status(&user_id, &job_index, &JobStatus::processing(stage_num)).await;
+        let _ = queue_ops.update_stage_status(&user_id, &job_index, stage_num, &StageStatus::Running).await;
     }
 
     // Process the job
@@ -915,8 +912,8 @@ pub async fn run_stage_job<W: StageWorker>(worker: W) -> Result<()> {
 
             // Update stage status
             if let Ok((user_id, job_index)) = QueueOps::parse_job_id(&job.job_id) {
-                let _ = queue_ops.update_stage_status(&user_id, job_index, stage_num, &StageStatus::Complete).await;
-                let _ = queue_ops.update_stage_logs(&user_id, job_index, stage_num, logs).await;
+                let _ = queue_ops.update_stage_status(&user_id, &job_index, stage_num, &StageStatus::Complete).await;
+                let _ = queue_ops.update_stage_logs(&user_id, &job_index, stage_num, logs).await;
             }
 
             JobResult {
@@ -939,9 +936,9 @@ pub async fn run_stage_job<W: StageWorker>(worker: W) -> Result<()> {
 
             // Update stage status
             if let Ok((user_id, job_index)) = QueueOps::parse_job_id(&job.job_id) {
-                let _ = queue_ops.update_stage_status(&user_id, job_index, stage_num, &StageStatus::Error).await;
-                let _ = queue_ops.update_job_status(&user_id, job_index, &JobStatus::error(logs.clone())).await;
-                let _ = queue_ops.update_stage_logs(&user_id, job_index, stage_num, logs).await;
+                let _ = queue_ops.update_stage_status(&user_id, &job_index, stage_num, &StageStatus::Error).await;
+                let _ = queue_ops.update_job_status(&user_id, &job_index, &JobStatus::error(logs.clone())).await;
+                let _ = queue_ops.update_stage_logs(&user_id, &job_index, stage_num, logs).await;
             }
 
             JobResult {

--- a/igait-stages/igait-stage7-finalize/src/main.rs
+++ b/igait-stages/igait-stage7-finalize/src/main.rs
@@ -183,7 +183,7 @@ impl FinalizeStageWorker {
     async fn update_job_status(&self, job_id: &str, status: JobStatus) {
         match QueueOps::parse_job_id(job_id) {
             Ok((user_id, job_index)) => {
-                if let Err(e) = self.queue_ops.update_job_status(&user_id, job_index, &status).await {
+                if let Err(e) = self.queue_ops.update_job_status(&user_id, &job_index, &status).await {
                     eprintln!("Failed to update job status in RTDB: {:?}", e);
                 }
             }
@@ -197,7 +197,7 @@ impl FinalizeStageWorker {
     async fn upload_stage_logs(&self, job_id: &str, logs: &str) {
         match QueueOps::parse_job_id(job_id) {
             Ok((user_id, job_index)) => {
-                if let Err(e) = self.queue_ops.update_stage_logs(&user_id, job_index, 7, logs).await {
+                if let Err(e) = self.queue_ops.update_stage_logs(&user_id, &job_index, 7, logs).await {
                     eprintln!("Failed to upload stage 7 logs to RTDB: {:?}", e);
                 }
             }
@@ -211,7 +211,7 @@ impl FinalizeStageWorker {
     async fn update_stage_status(&self, job_id: &str, stage: u8, status: StageStatus) {
         match QueueOps::parse_job_id(job_id) {
             Ok((user_id, job_index)) => {
-                if let Err(e) = self.queue_ops.update_stage_status(&user_id, job_index, stage, &status).await {
+                if let Err(e) = self.queue_ops.update_stage_status(&user_id, &job_index, stage, &status).await {
                     eprintln!("Failed to update stage {} status in RTDB: {:?}", stage, e);
                 }
             }


### PR DESCRIPTION
## Summary
- Replace sequential integer job indices with UUID v4 keys
- `new_job` generates a UUID and returns it; job ID format remains `{uid}_{key}`
- `job_index: usize` → `job_key: String` across backend, igait-lib, stage 7, and frontend
- Eliminates race conditions from concurrent submissions

## Follow-up to
PR #79 (merged) switched RTDB jobs to objects and fixed the `.set()` → `.update()` POST/PATCH issue. This PR completes the migration by replacing sequential indices with unique keys.

## Test plan
- [ ] Submit a job — verify RTDB key is a UUID, not an integer
- [ ] Submit concurrent jobs — no overwrites
- [ ] Rerun and video-edit work with UUID-based job IDs
- [ ] Admin panel shows correct job IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)