### PR TITLE
fix: recover orphaned jobs when K8s pods crash

### DIFF
--- a/igait-backend/Cargo.lock
+++ b/igait-backend/Cargo.lock
@@ -2361,6 +2361,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ts-rs",
+ "uuid",
 ]
 
 [[package]]
@@ -4584,6 +4585,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/igait-backend/src/helper/orchestrator.rs
+++ b/igait-backend/src/helper/orchestrator.rs
@@ -219,6 +219,9 @@ impl Orchestrator {
             "IGAIT_JOB_PAYLOAD",
             &payload,
             &resources,
+            stage,
+            &job.job_id,
+            &job.user_id,
         );
 
         let jobs_api: Api<Job> = Api::namespaced(self.kube_client.clone(), NAMESPACE);
@@ -247,6 +250,9 @@ impl Orchestrator {
             "IGAIT_FINALIZE_PAYLOAD",
             &payload,
             &resources,
+            stage,
+            &job.job_id,
+            &job.user_id,
         );
 
         let jobs_api: Api<Job> = Api::namespaced(self.kube_client.clone(), NAMESPACE);
@@ -265,6 +271,9 @@ impl Orchestrator {
         payload_env_var: &str,
         payload: &str,
         resources: &StageResources,
+        stage: StageNumber,
+        job_id: &str,
+        user_id: &str,
     ) -> Job {
         let mut resource_requests = std::collections::BTreeMap::new();
         resource_requests.insert("cpu".to_string(), Quantity(resources.cpu_request.to_string()));
@@ -287,6 +296,11 @@ impl Orchestrator {
                 labels: Some(std::collections::BTreeMap::from([
                     ("app".to_string(), "igait-pipeline".to_string()),
                     ("managed-by".to_string(), "igait-backend".to_string()),
+                    ("igait.niu.edu/stage".to_string(), stage.as_u8().to_string()),
+                ])),
+                annotations: Some(std::collections::BTreeMap::from([
+                    ("igait.niu.edu/job-id".to_string(), job_id.to_string()),
+                    ("igait.niu.edu/user-id".to_string(), user_id.to_string()),
                 ])),
                 ..Default::default()
             },
@@ -551,9 +565,58 @@ impl Orchestrator {
 
             if is_failed || is_deadline_exceeded {
                 warn!("K8s Job {} is failed/timed out, cleaning up", job_name);
-                // The TTL controller will clean up the Job object itself.
-                // We just need to ensure the in-flight tracking is updated.
-                // The job_results check will handle the RTDB side if a result was written.
+
+                // Extract job_id and stage from annotations/labels so we can
+                // write a synthetic failure result for the completion monitor.
+                let annotations = k8s_job.metadata.annotations.as_ref();
+                let labels = k8s_job.metadata.labels.as_ref();
+
+                let job_id = annotations.and_then(|a| a.get("igait.niu.edu/job-id"));
+                let stage_str = labels.and_then(|l| l.get("igait.niu.edu/stage"));
+
+                if let (Some(job_id), Some(stage_str)) = (job_id, stage_str) {
+                    let stage_num: u8 = stage_str.parse().unwrap_or(0);
+
+                    // Only write a failure result if one doesn't already exist
+                    let result_path = job_result_path(job_id);
+                    let existing: Option<serde_json::Value> = self.rtdb.get(&result_path).await.unwrap_or(None);
+
+                    if existing.is_none() {
+                        let reason = if is_deadline_exceeded { "timed out" } else { "crashed" };
+                        warn!("Writing synthetic failure result for job {} stage {} ({})", job_id, stage_num, reason);
+
+                        let user_id = annotations
+                            .and_then(|a| a.get("igait.niu.edu/user-id"))
+                            .cloned()
+                            .unwrap_or_default();
+
+                        let failure_result = JobResult {
+                            stage: stage_num,
+                            success: false,
+                            output_keys: HashMap::new(),
+                            error: Some(format!("K8s Job {}: pod {}", reason, job_name)),
+                            logs: format!("Stage {} pod {} without writing a result", stage_num, reason),
+                            duration_ms: 0,
+                            job_id: job_id.clone(),
+                            user_id,
+                            metadata: JobMetadata::default(),
+                            input_keys: HashMap::new(),
+                            requires_approval: false,
+                            approved: false,
+                        };
+
+                        if let Err(e) = self.rtdb.set(&result_path, &failure_result).await {
+                            error!("Failed to write synthetic failure result for {}: {}", job_id, e);
+                        }
+                    }
+                } else {
+                    warn!("K8s Job {} missing igait annotations, cannot recover — will be cleaned up by TTL", job_name);
+                }
+
+                // Remove from in-flight tracking regardless
+                if let Some(job_id) = annotations.and_then(|a| a.get("igait.niu.edu/job-id")) {
+                    self.in_flight.write().await.remove(job_id);
+                }
             }
         }
 

--- a/igait-lib/src/microservice/queue.rs
+++ b/igait-lib/src/microservice/queue.rs
@@ -368,6 +368,7 @@ pub struct JobResult {
     /// The original user ID.
     pub user_id: String,
     /// The original job metadata (needed for stage transitions).
+    #[serde(default)]
     pub metadata: JobMetadata,
     /// The original input keys (needed for reconstructing QueueItem).
     #[serde(default)]


### PR DESCRIPTION
## Summary
- **Firebase null pruning bug**: `JobResult.metadata` deserialization failed when Firebase pruned empty `metadata.extra` objects, breaking the completion monitor for *all* jobs (not just the affected one). Fixed with `#[serde(default)]`.
- **Stale job recovery**: `check_stale_jobs()` previously only logged failed K8s Jobs without taking action. Now writes a synthetic failure `JobResult` to RTDB so `check_completions()` routes the job to the finalize queue — marking it as errored instead of stuck forever.
- **K8s Job annotations**: Added `igait.niu.edu/job-id`, `igait.niu.edu/user-id` annotations and `igait.niu.edu/stage` label to K8s Job specs, enabling `check_stale_jobs()` to identify which pipeline job a crashed pod belongs to.

### Context
Investigated job `mKNYHWBJomQbBiQiWBpSQFco2B13_9ab53f2b-dfb0-4c6f-9545-ea37cf1c6f50` which was stuck at "Stage 1 Processing" indefinitely. The stage 1 K8s Job hit `BackoffLimitExceeded` (3 pod crashes) before writing a result, and no recovery path existed. Manually cleaned up the orphaned RTDB state.

## Test plan
- [ ] Deploy backend and submit a test job — verify annotations/labels appear on K8s Job
- [ ] Verify completion monitor no longer errors on jobs with empty metadata
- [ ] Simulate a pod crash (e.g. kill the pod mid-processing) and verify the job transitions to Error state via finalize

🤖 Generated with [Claude Code](https://claude.com/claude-code)