### PR TITLE
fix: prevent CI deploy race condition

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -65,15 +65,16 @@ jobs:
       - name: Update deployment image tag
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          sed -i "s|image: ghcr.io/igait-niu/igait/igait-backend:.*|image: ghcr.io/igait-niu/igait/igait-backend:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
-          git add igait-kubernetes-configs/
-          git diff --cached --quiet && exit 0
-          git commit -m "deploy: igait-backend:sha-${SHA_SHORT}"
           for i in 1 2 3 4 5; do
-            git push && exit 0
-            git pull --rebase
+            git fetch origin master
+            git reset --hard origin/master
+            sed -i "s|image: ghcr.io/igait-niu/igait/igait-backend:.*|image: ghcr.io/igait-niu/igait/igait-backend:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
+            git add igait-kubernetes-configs/
+            git diff --cached --quiet && echo "Already up to date" && exit 0
+            git commit -m "deploy: igait-backend:sha-${SHA_SHORT}"
+            git push origin master && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-stage1.yml
+++ b/.github/workflows/build-stage1.yml
@@ -65,15 +65,16 @@ jobs:
       - name: Update deployment image tag
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage1-media-conversion:.*|value: ghcr.io/igait-niu/igait/igait-stage1-media-conversion:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
-          git add igait-kubernetes-configs/
-          git diff --cached --quiet && exit 0
-          git commit -m "deploy: igait-stage1-media-conversion:sha-${SHA_SHORT}"
           for i in 1 2 3 4 5; do
-            git push && exit 0
-            git pull --rebase
+            git fetch origin master
+            git reset --hard origin/master
+            sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage1-media-conversion:.*|value: ghcr.io/igait-niu/igait/igait-stage1-media-conversion:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
+            git add igait-kubernetes-configs/
+            git diff --cached --quiet && echo "Already up to date" && exit 0
+            git commit -m "deploy: igait-stage1-media-conversion:sha-${SHA_SHORT}"
+            git push origin master && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-stage2.yml
+++ b/.github/workflows/build-stage2.yml
@@ -67,15 +67,16 @@ jobs:
       - name: Update deployment image tag
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage2-validity-check:.*|value: ghcr.io/igait-niu/igait/igait-stage2-validity-check:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
-          git add igait-kubernetes-configs/
-          git diff --cached --quiet && exit 0
-          git commit -m "deploy: igait-stage2-validity-check:sha-${SHA_SHORT}"
           for i in 1 2 3 4 5; do
-            git push && exit 0
-            git pull --rebase
+            git fetch origin master
+            git reset --hard origin/master
+            sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage2-validity-check:.*|value: ghcr.io/igait-niu/igait/igait-stage2-validity-check:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
+            git add igait-kubernetes-configs/
+            git diff --cached --quiet && echo "Already up to date" && exit 0
+            git commit -m "deploy: igait-stage2-validity-check:sha-${SHA_SHORT}"
+            git push origin master && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-stage3.yml
+++ b/.github/workflows/build-stage3.yml
@@ -65,15 +65,16 @@ jobs:
       - name: Update deployment image tag
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage3-reframing:.*|value: ghcr.io/igait-niu/igait/igait-stage3-reframing:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
-          git add igait-kubernetes-configs/
-          git diff --cached --quiet && exit 0
-          git commit -m "deploy: igait-stage3-reframing:sha-${SHA_SHORT}"
           for i in 1 2 3 4 5; do
-            git push && exit 0
-            git pull --rebase
+            git fetch origin master
+            git reset --hard origin/master
+            sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage3-reframing:.*|value: ghcr.io/igait-niu/igait/igait-stage3-reframing:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
+            git add igait-kubernetes-configs/
+            git diff --cached --quiet && echo "Already up to date" && exit 0
+            git commit -m "deploy: igait-stage3-reframing:sha-${SHA_SHORT}"
+            git push origin master && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-stage4.yml
+++ b/.github/workflows/build-stage4.yml
@@ -67,15 +67,16 @@ jobs:
       - name: Update deployment image tag
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage4-pose-estimation:.*|value: ghcr.io/igait-niu/igait/igait-stage4-pose-estimation:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
-          git add igait-kubernetes-configs/
-          git diff --cached --quiet && exit 0
-          git commit -m "deploy: igait-stage4-pose-estimation:sha-${SHA_SHORT}"
           for i in 1 2 3 4 5; do
-            git push && exit 0
-            git pull --rebase
+            git fetch origin master
+            git reset --hard origin/master
+            sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage4-pose-estimation:.*|value: ghcr.io/igait-niu/igait/igait-stage4-pose-estimation:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
+            git add igait-kubernetes-configs/
+            git diff --cached --quiet && echo "Already up to date" && exit 0
+            git commit -m "deploy: igait-stage4-pose-estimation:sha-${SHA_SHORT}"
+            git push origin master && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-stage5.yml
+++ b/.github/workflows/build-stage5.yml
@@ -67,15 +67,16 @@ jobs:
       - name: Update deployment image tag
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage5-cycle-detection:.*|value: ghcr.io/igait-niu/igait/igait-stage5-cycle-detection:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
-          git add igait-kubernetes-configs/
-          git diff --cached --quiet && exit 0
-          git commit -m "deploy: igait-stage5-cycle-detection:sha-${SHA_SHORT}"
           for i in 1 2 3 4 5; do
-            git push && exit 0
-            git pull --rebase
+            git fetch origin master
+            git reset --hard origin/master
+            sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage5-cycle-detection:.*|value: ghcr.io/igait-niu/igait/igait-stage5-cycle-detection:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
+            git add igait-kubernetes-configs/
+            git diff --cached --quiet && echo "Already up to date" && exit 0
+            git commit -m "deploy: igait-stage5-cycle-detection:sha-${SHA_SHORT}"
+            git push origin master && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-stage6.yml
+++ b/.github/workflows/build-stage6.yml
@@ -67,15 +67,16 @@ jobs:
       - name: Update deployment image tag
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage6-prediction:.*|value: ghcr.io/igait-niu/igait/igait-stage6-prediction:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
-          git add igait-kubernetes-configs/
-          git diff --cached --quiet && exit 0
-          git commit -m "deploy: igait-stage6-prediction:sha-${SHA_SHORT}"
           for i in 1 2 3 4 5; do
-            git push && exit 0
-            git pull --rebase
+            git fetch origin master
+            git reset --hard origin/master
+            sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage6-prediction:.*|value: ghcr.io/igait-niu/igait/igait-stage6-prediction:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
+            git add igait-kubernetes-configs/
+            git diff --cached --quiet && echo "Already up to date" && exit 0
+            git commit -m "deploy: igait-stage6-prediction:sha-${SHA_SHORT}"
+            git push origin master && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-stage7.yml
+++ b/.github/workflows/build-stage7.yml
@@ -65,15 +65,16 @@ jobs:
       - name: Update deployment image tag
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage7-finalize:.*|value: ghcr.io/igait-niu/igait/igait-stage7-finalize:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
-          git add igait-kubernetes-configs/
-          git diff --cached --quiet && exit 0
-          git commit -m "deploy: igait-stage7-finalize:sha-${SHA_SHORT}"
           for i in 1 2 3 4 5; do
-            git push && exit 0
-            git pull --rebase
+            git fetch origin master
+            git reset --hard origin/master
+            sed -i "s|value: ghcr.io/igait-niu/igait/igait-stage7-finalize:.*|value: ghcr.io/igait-niu/igait/igait-stage7-finalize:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-backend/deployment.yaml
+            git add igait-kubernetes-configs/
+            git diff --cached --quiet && echo "Already up to date" && exit 0
+            git commit -m "deploy: igait-stage7-finalize:sha-${SHA_SHORT}"
+            git push origin master && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -73,15 +73,16 @@ jobs:
       - name: Update deployment image tag
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          sed -i "s|image: ghcr.io/igait-niu/igait/igait-frontend:.*|image: ghcr.io/igait-niu/igait/igait-frontend:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-frontend/deployment.yaml
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
-          git add igait-kubernetes-configs/
-          git diff --cached --quiet && exit 0
-          git commit -m "deploy: igait-frontend:sha-${SHA_SHORT}"
           for i in 1 2 3 4 5; do
-            git push && exit 0
-            git pull --rebase
+            git fetch origin master
+            git reset --hard origin/master
+            sed -i "s|image: ghcr.io/igait-niu/igait/igait-frontend:.*|image: ghcr.io/igait-niu/igait/igait-frontend:sha-${SHA_SHORT}|" igait-kubernetes-configs/igait-frontend/deployment.yaml
+            git add igait-kubernetes-configs/
+            git diff --cached --quiet && echo "Already up to date" && exit 0
+            git commit -m "deploy: igait-frontend:sha-${SHA_SHORT}"
+            git push origin master && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/igait-kubernetes-configs/igait-backend/deployment.yaml
+++ b/igait-kubernetes-configs/igait-backend/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       serviceAccountName: igait-backend
       containers:
-      - image: ghcr.io/igait-niu/igait/igait-backend:sha-db64df8
+      - image: ghcr.io/igait-niu/igait/igait-backend:sha-5038bf7
         name: igait-backend
         ports:
         - containerPort: 3000


### PR DESCRIPTION
## Summary
- All 9 build workflows used `git pull --rebase` to retry failed deploy pushes, which fails with merge conflicts when concurrent workflows edit the same `deployment.yaml`
- Replaced with a `fetch origin master` → `reset --hard` → `sed` → `commit` → `push` loop that always applies the image tag update to a fresh copy of master, making conflicts impossible
- Also bumps the backend deployment to `sha-5038bf7` (stages 3/6 resource limits fix from #84) which the CI failed to deploy due to this race condition

### Root cause
When PRs #83 and #84 merged in quick succession, two backend CI runs triggered. The first deployed `sha-db64df8` successfully. The second tried to rebase its deploy commit on top, but both edited the same `image:` line — causing an unresolvable merge conflict.

## Test plan
- [ ] Merge this PR and verify the deploy commit lands on master
- [ ] Merge two PRs in quick succession that trigger the same build workflow — verify both deploy commits succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)