### PR TITLE
fix(approval): rule grant, UI lock, and error banners

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -4,7 +4,15 @@
       ".read": "auth != null && root.child('users').child(auth.uid).child('administrator').val() == true",
       "$uid": {
         ".read": "auth != null && auth.uid == $uid",
-        ".write": false
+        ".write": false,
+        "jobs": {
+          "$job_key": {
+            "approved": {
+              ".write": "auth != null && root.child('users').child(auth.uid).child('administrator').val() == true",
+              ".validate": "newData.isBoolean()"
+            }
+          }
+        }
       }
     },
     "queues": {

--- a/igait-frontend/src/lib/components/jobs/JobsDataTable.svelte
+++ b/igait-frontend/src/lib/components/jobs/JobsDataTable.svelte
@@ -18,7 +18,7 @@
 		selectedId?: string | null;
 		selectable?: boolean;
 		onRowClick?: (job: JobWithId) => void;
-		onApprove?: (jobIds: string[]) => void;
+		onApprove?: (jobIds: string[]) => void | Promise<void>;
 	}
 
 	let {
@@ -33,16 +33,26 @@
 	}: Props = $props();
 
 	let selectedIds = new SvelteSet<string>();
+	let approving = $state(false);
 
 	function toggleSelect(id: string) {
+		const job = jobsWithIds.find((j) => j.id === id);
+		if (job?.approved) return;
 		if (selectedIds.has(id)) selectedIds.delete(id);
 		else selectedIds.add(id);
 	}
 
-	function handleApprove() {
-		if (onApprove && selectedIds.size > 0) {
-			onApprove([...selectedIds]);
+	async function handleApprove() {
+		if (!onApprove || selectedIds.size === 0 || approving) return;
+		const ids = [...selectedIds];
+		approving = true;
+		try {
+			await onApprove(ids);
+			// Only clear selection on success — preserves the user's selection
+			// so they can retry after an error without re-picking rows.
 			selectedIds.clear();
+		} finally {
+			approving = false;
 		}
 	}
 
@@ -141,15 +151,18 @@
 		return filtered;
 	});
 
+	const selectableFilteredData = $derived(filteredData.filter((j) => !j.approved));
+
 	const allFilteredSelected = $derived(
-		filteredData.length > 0 && filteredData.every((j) => selectedIds.has(j.id))
+		selectableFilteredData.length > 0 &&
+			selectableFilteredData.every((j) => selectedIds.has(j.id))
 	);
 
 	function toggleSelectAll() {
 		if (allFilteredSelected) {
 			selectedIds.clear();
 		} else {
-			for (const j of filteredData) selectedIds.add(j.id);
+			for (const j of selectableFilteredData) selectedIds.add(j.id);
 		}
 	}
 
@@ -214,9 +227,15 @@
 	{#if selectable && selectedIds.size > 0}
 		<div class="selection-bar">
 			<span class="selection-count">{selectedIds.size} selected</span>
-			<Button variant="default" size="sm" class="approve-selected-btn" onclick={handleApprove}>
+			<Button
+				variant="default"
+				size="sm"
+				class="approve-selected-btn"
+				onclick={handleApprove}
+				disabled={approving}
+			>
 				<ShieldCheck class="approve-icon" />
-				Approve Selected
+				{approving ? 'Approving…' : 'Approve Selected'}
 			</Button>
 		</div>
 	{/if}
@@ -231,6 +250,7 @@
 								type="checkbox"
 								checked={allFilteredSelected}
 								onchange={toggleSelectAll}
+								disabled={selectableFilteredData.length === 0}
 								class="row-checkbox"
 							/>
 						</Table.Head>
@@ -261,18 +281,29 @@
 						<Table.Row
 							class="data-row {selectedId === job.id ? 'row-selected' : ''} {onRowClick
 								? 'row-clickable'
-								: ''}"
+								: ''} {selectable && job.approved ? 'row-approved' : ''}"
 							onclick={() => onRowClick?.(job)}
 						>
 							{#if selectable}
 								<Table.Cell>
-									<input
-										type="checkbox"
-										checked={selectedIds.has(job.id)}
-										onchange={() => toggleSelect(job.id)}
-										onclick={(e) => e.stopPropagation()}
-										class="row-checkbox"
-									/>
+									{#if job.approved}
+										<span
+											class="approved-indicator"
+											title="Already approved"
+											onclick={(e) => e.stopPropagation()}
+											role="presentation"
+										>
+											<ShieldCheck class="approved-icon" />
+										</span>
+									{:else}
+										<input
+											type="checkbox"
+											checked={selectedIds.has(job.id)}
+											onchange={() => toggleSelect(job.id)}
+											onclick={(e) => e.stopPropagation()}
+											class="row-checkbox"
+										/>
+									{/if}
 								</Table.Cell>
 							{/if}
 							<Table.Cell>
@@ -420,6 +451,33 @@
 		width: 0.875rem;
 		height: 0.875rem;
 		accent-color: hsl(var(--primary));
+	}
+
+	.row-checkbox:disabled {
+		cursor: not-allowed;
+		opacity: 0.4;
+	}
+
+	:global(.data-row.row-approved) {
+		opacity: 0.65;
+		background-color: hsl(142 76% 36% / 0.04);
+	}
+
+	:global(.data-row.row-approved:hover) {
+		opacity: 0.85;
+	}
+
+	.approved-indicator {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		color: hsl(142 76% 36%);
+		cursor: default;
+	}
+
+	:global(.approved-icon) {
+		width: 0.9375rem;
+		height: 0.9375rem;
 	}
 
 	.selection-bar {

--- a/igait-frontend/src/routes/(authenticated)/admin/queues/+page.svelte
+++ b/igait-frontend/src/routes/(authenticated)/admin/queues/+page.svelte
@@ -31,6 +31,9 @@
 	let configState: QueueConfigState = $state({ status: 'loading' });
 	let activeStage: string = $state('stage_1');
 
+	let approveError: string | null = $state(null);
+	let approveSuccess: string | null = $state(null);
+
 	// ── Subscriptions ──────────────────────────────────────
 
 	const unsubQueues = subscribeToQueues((state) => {
@@ -102,6 +105,8 @@
 
 	function handleSelectStage(stageKey: string) {
 		activeStage = stageKey;
+		approveError = null;
+		approveSuccess = null;
 	}
 
 	function handleSelectJob(job: Job & { id: string }) {
@@ -113,11 +118,41 @@
 	}
 
 	async function handleApproveJobs(jobIds: string[]) {
-		for (const { key, item } of activeQueueEntries) {
-			if (jobIds.includes(item.job_id)) {
-				await approveQueueItem(activeStage, key, item);
-			}
+		approveError = null;
+		approveSuccess = null;
+
+		const targets = activeQueueEntries.filter(({ item }) => jobIds.includes(item.job_id));
+
+		if (targets.length === 0) {
+			approveError = 'Selected jobs are no longer in this queue.';
+			throw new Error(approveError);
 		}
+
+		const results = await Promise.allSettled(
+			targets.map(({ key, item }) => approveQueueItem(activeStage, key, item))
+		);
+
+		const failures = results.filter(
+			(r): r is PromiseRejectedResult => r.status === 'rejected'
+		);
+		const succeeded = results.length - failures.length;
+
+		if (failures.length === 0) {
+			approveSuccess = `Approved ${succeeded} job${succeeded === 1 ? '' : 's'}.`;
+			return;
+		}
+
+		const firstReason =
+			failures[0].reason instanceof Error
+				? failures[0].reason.message
+				: String(failures[0].reason);
+		approveError =
+			succeeded > 0
+				? `Approved ${succeeded} of ${results.length}; ${failures.length} failed: ${firstReason}`
+				: `Approval failed: ${firstReason}`;
+
+		// Re-throw so the table keeps the selection intact for retry.
+		throw new Error(approveError);
 	}
 </script>
 
@@ -178,6 +213,17 @@
 						<Switch checked={activeRequiresApproval} onCheckedChange={handleToggleApproval} />
 					</label>
 				</div>
+
+				{#if approveError}
+					<div class="approve-banner approve-banner--error" role="alert">
+						{approveError}
+					</div>
+				{/if}
+				{#if approveSuccess}
+					<div class="approve-banner approve-banner--success" role="status">
+						{approveSuccess}
+					</div>
+				{/if}
 
 				<!-- Content -->
 				<div class="content-area">
@@ -379,6 +425,29 @@
 		font-weight: 500;
 		color: var(--foreground);
 		user-select: none;
+	}
+
+	/* ── Approve Banner ─────────────────────────────────── */
+
+	.approve-banner {
+		margin: 0.625rem 0.875rem 0;
+		padding: 0.5rem 0.75rem;
+		border-radius: var(--radius-sm, 0.375rem);
+		font-size: 0.8125rem;
+		line-height: 1.4;
+		border: 1px solid;
+	}
+
+	.approve-banner--error {
+		background: oklch(from var(--destructive) l c h / 0.1);
+		border-color: oklch(from var(--destructive) l c h / 0.3);
+		color: var(--destructive);
+	}
+
+	.approve-banner--success {
+		background: oklch(0.65 0.18 142 / 0.1);
+		border-color: oklch(0.65 0.18 142 / 0.3);
+		color: oklch(0.45 0.18 142);
 	}
 
 	/* ── Content Area ───────────────────────────────────── */


### PR DESCRIPTION
## Summary
- **Firebase rule fix**: grants admins `.write` on `users/$uid/jobs/$job_key/approved` (leaf-scoped + boolean validator). Resolves the `PERMISSION_DENIED` that silently broke the approve button.
- **Per-row UI lock**: approved jobs render a `ShieldCheck` indicator instead of a checkbox, are excluded from select-all, and get muted/green-tinted row styling — makes it obvious which jobs are already handled during the brief window before the worker claims them.
- **Error surfacing**: approvals now run through `Promise.allSettled`, with an inline banner above the queue table reporting success count or partial/full failure. Selection is preserved on error so the admin can retry without re-picking rows.

## Root cause
`database.rules.json` denied all writes under `/users/$uid/**`. The approve handler needed to set both `/queues/.../approved` (already permitted) and `/users/$uid/jobs/.../approved` (blocked) — so the queue-side write succeeded while the user-side write failed silently in the browser console, leaving admins unsure whether the action took effect.

## Test plan
- [x] Deploy rules (`firebase deploy --only database` or equivalent) so the RTDB starts honoring the new grant.
- [ ] As an admin, toggle Manual Approval on a stage; approve a queued job → verify both `/queues/{stage}/{key}/approved` and `/users/{uid}/jobs/{key}/approved` are `true` in RTDB.
- [ ] Approved row in the queue table shows `ShieldCheck` indicator, greyed appearance, not selectable.
- [ ] Bulk-approve multiple rows → success banner shows correct count; selection clears.
- [ ] Revert rules locally to simulate failure → approve click produces red error banner, selection preserved for retry.
- [ ] Switch stage tabs → banners clear.
- [ ] Non-admin cannot write to `/users/$uid/jobs/$key/approved` (attempt via client SDK as a logged-in non-admin user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)