### PR TITLE
fix(rerun): reset approval flag so rerun respects the approval gate

### DIFF
--- a/igait-backend/src/routes/rerun.rs
+++ b/igait-backend/src/routes/rerun.rs
@@ -238,6 +238,18 @@ async fn run_rerun_under_lease(
             .context(format!("Failed to reset stage status for stage {}", s))?;
     }
 
+    // ── 6a. Reset the job's approval flag ──────────────────────────
+    // A rerun is a fresh pass through the approval gate. The prior
+    // admin greenlight applied to the original submission (and its
+    // original inputs/video_edit); this rerun may have different
+    // parameters and is a new decision to make. Force re-approval by
+    // clearing the flag on the user-visible record. The queue item
+    // below will also default to `approved: false` (via QueueItem::new).
+    let approved_path = format!("users/{}/jobs/{}/approved", target_uid, job_key);
+    rtdb.set(&approved_path, &false)
+        .await
+        .context("Failed to reset job approved flag")?;
+
     // ── 7. Build a fresh QueueItem and write it to the target queue ─
     let input_keys = build_input_keys(job_id, stage);
 
@@ -260,14 +272,13 @@ async fn run_rerun_under_lease(
         extra,
     };
 
-    let mut queue_item = QueueItem::new(
+    let queue_item = QueueItem::new(
         job_id.to_string(),
         target_uid.to_string(),
         input_keys,
         metadata,
         job.requires_approval,
     );
-    queue_item.approved = true;
 
     let path = queue_item_path(target_stage, job_id);
     rtdb.set(&path, &queue_item)


### PR DESCRIPTION
## Summary
Rerunning a job was silently bypassing the per-stage approval gate. The handler unconditionally set `queue_item.approved = true` on the re-queued item, so even stages with `queue_config.requires_approval == true` would get claimed without an admin re-approving. This patch drops that override and resets the user-side `approved` flag for UI consistency.

## Root cause
`igait-backend/src/routes/rerun.rs:270` (pre-patch):
```rust
let mut queue_item = QueueItem::new(…, job.requires_approval);
queue_item.approved = true;   // ← bypassed the gate unconditionally
```
`QueueItem::new` already defaults `approved: false`. The explicit override meant every rerun — regardless of target stage — was pre-approved before the admin had a chance to review.

## Changes
- **Drop the `approved = true` override** in `run_rerun_under_lease` — re-queued items now start at `approved: false` (matching `QueueItem::new`'s default). The worker then honors `queue_config[target_stage].requires_approval` exactly as it does for fresh submissions.
- **Reset `users/$uid/jobs/$job_key/approved = false`** alongside the existing stage_logs/stage_statuses reset, so the admin queue UI shows the row as unapproved (re-enabling the approve checkbox added in #91).

## Behavior after the fix
| Target stage's `requires_approval` | Before | After |
|---|---|---|
| `false` (auto-approve) | Claimed immediately | Claimed immediately (no change) |
| `true` (gated) | **Claimed immediately (bug)** | Waits for admin approval |

No added friction for stages configured to auto-approve. Only stages explicitly gated by `requires_approval` now prompt an admin on rerun.

## Test plan
- [ ] Set `queue_config/stage_4/requires_approval = true`.
- [ ] Run a job through stages 1–4; approve through the gate.
- [ ] Rerun from stage 4 as admin.
- [ ] Verify the new `queues/stage_4/<job_id>/approved` is `false` (not `true`).
- [ ] Verify `users/<uid>/jobs/<key>/approved` is `false` and the admin queue UI shows the row as re-approvable (checkbox, not `ShieldCheck` indicator).
- [ ] Verify worker does **not** pick up the job until admin re-approves via the UI.
- [ ] Set `queue_config/stage_4/requires_approval = false`, rerun again → verify worker picks up immediately with no admin action.
- [ ] Rerun from stage 1 with `video_edit` set → verify `video_edit` still flows through (unrelated but in the same code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)