### PR TITLE
fix(finalize): migrate residual u8 stage indices to StageId

### DIFF
--- a/igait-lib/src/microservice/email.rs
+++ b/igait-lib/src/microservice/email.rs
@@ -251,7 +251,7 @@ impl EmailTemplates {
     /// Sent when the pipeline encounters an error at any stage.
     pub fn processing_failure(
         datetime: &str,
-        failed_stage: Option<u8>,
+        failed_stage: Option<crate::microservice::registry::StageId>,
         error: &str,
         uid: &str,
         job_id: &str,

--- a/igait-stages/finalize/src/main.rs
+++ b/igait-stages/finalize/src/main.rs
@@ -350,7 +350,7 @@ async fn run_finalize_job_mode() -> Result<()> {
         ProcessingResult::Success { output_keys, logs, duration_ms } => {
             println!("[job-mode] Finalize job {} completed in {}ms", job.job_id, duration_ms);
             JobResult {
-                stage: 7,
+                stage: StageId::new("finalize"),
                 success: true,
                 output_keys: output_keys.clone(),
                 error: None,
@@ -371,7 +371,7 @@ async fn run_finalize_job_mode() -> Result<()> {
         ProcessingResult::Failure { error, logs, duration_ms } => {
             eprintln!("[job-mode] Finalize job {} failed after {}ms: {}", job.job_id, duration_ms, error);
             JobResult {
-                stage: 7,
+                stage: StageId::new("finalize"),
                 success: false,
                 output_keys: HashMap::new(),
                 error: Some(error.clone()),


### PR DESCRIPTION
## Summary
- Widen `EmailTemplates::processing_failure`'s `failed_stage` param from `Option<u8>` to `Option<StageId>` (finalize is the only caller).
- Replace two `JobResult { stage: 7, .. }` literals in finalize with `StageId::new("finalize")`.

These were the last residual numeric stage references left over from the stage-unordering refactor — the finalize crate wouldn't compile against the new registry-typed `JobResult.stage` / `JobRecord.failed_at_stage`.

## Test plan
- [x] `cargo build --release` in `igait-stages/finalize` — succeeds
- [ ] CI build for finalize stage is green
- [ ] Sanity check a failure-path job: email should render the stage key (e.g. `Stage reframing`) instead of a numeric index

🤖 Generated with [Claude Code](https://claude.com/claude-code)