### PR TITLE
fix(submit): restore consistent borders and controls on submission form

### DIFF
--- a/igait-frontend/src/routes/(authenticated)/submit/+page.svelte
+++ b/igait-frontend/src/routes/(authenticated)/submit/+page.svelte
@@ -198,7 +198,7 @@
 
 					<div class="form-grid">
 						<div class="form-group">
-							<Label for="age">Age *</Label>
+							<Label for="age">Age (years) *</Label>
 							<Input
 								id="age"
 								type="number"
@@ -242,7 +242,7 @@
 						/>
 
 						<div class="form-group height-group">
-							<Label>Height *</Label>
+							<Label>Height (ft / in) *</Label>
 							<div class="height-inputs">
 								<Input
 									id="heightFeet"
@@ -388,6 +388,17 @@
 		display: flex;
 		flex-direction: column;
 		gap: 1.5rem;
+	}
+
+	.submit-form :global(input[type='number']) {
+		-moz-appearance: textfield;
+		appearance: textfield;
+	}
+
+	.submit-form :global(input[type='number']::-webkit-outer-spin-button),
+	.submit-form :global(input[type='number']::-webkit-inner-spin-button) {
+		-webkit-appearance: none;
+		margin: 0;
 	}
 
 	:global(.form-error) {

--- a/igait-frontend/src/routes/(authenticated)/submit/FormSelect.svelte
+++ b/igait-frontend/src/routes/(authenticated)/submit/FormSelect.svelte
@@ -67,12 +67,12 @@
 		height: 2.25rem;
 		width: 100%;
 		border-radius: var(--radius-md);
-		border: 1px solid hsl(var(--input));
-		background-color: hsl(var(--background));
+		border: 1px solid var(--input);
+		background-color: var(--background);
 		padding: 0 0.75rem;
 		font-size: 0.875rem;
 		font-weight: 500;
-		color: hsl(var(--foreground));
+		color: var(--foreground);
 		box-shadow: var(--shadow-xs);
 		transition:
 			box-shadow 0.2s,
@@ -88,8 +88,8 @@
 	}
 
 	.select-input:focus {
-		border-color: hsl(var(--ring));
-		box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+		border-color: var(--ring);
+		box-shadow: 0 0 0 2px color-mix(in oklch, var(--ring) 20%, transparent);
 	}
 
 	.select-input:disabled {
@@ -98,15 +98,15 @@
 	}
 
 	.select-input--error {
-		border-color: hsl(var(--destructive));
+		border-color: var(--destructive);
 	}
 
 	.select-input--error:focus {
-		box-shadow: 0 0 0 2px hsl(var(--destructive) / 0.2);
+		box-shadow: 0 0 0 2px color-mix(in oklch, var(--destructive) 20%, transparent);
 	}
 
 	.form-field__error {
 		font-size: 0.75rem;
-		color: hsl(var(--destructive));
+		color: var(--destructive);
 	}
 </style>

--- a/igait-frontend/src/routes/(authenticated)/submit/VideoUploadArea.svelte
+++ b/igait-frontend/src/routes/(authenticated)/submit/VideoUploadArea.svelte
@@ -99,23 +99,23 @@
 		align-items: center;
 		justify-content: center;
 		padding: 1.25rem;
-		border: 2px dashed hsl(var(--border));
+		border: 2px dashed var(--border);
 		border-radius: var(--radius-lg);
 		cursor: pointer;
 		transition: all 0.2s;
-		background-color: hsl(var(--muted) / 0.3);
+		background-color: color-mix(in oklch, var(--muted) 30%, transparent);
 		min-height: 140px;
 		gap: 0.5rem;
 	}
 
 	.upload-area:hover:not(.disabled) {
-		border-color: hsl(var(--primary));
-		background-color: hsl(var(--primary) / 0.05);
+		border-color: var(--primary);
+		background-color: color-mix(in oklch, var(--primary) 5%, transparent);
 	}
 
 	.upload-area.has-file {
-		border-color: hsl(var(--primary));
-		background-color: hsl(var(--primary) / 0.1);
+		border-color: var(--primary);
+		background-color: color-mix(in oklch, var(--primary) 10%, transparent);
 	}
 
 	.upload-area.disabled {
@@ -124,32 +124,32 @@
 	}
 
 	.upload-area.dragging {
-		border-color: hsl(var(--primary));
-		background-color: hsl(var(--primary) / 0.15);
+		border-color: var(--primary);
+		background-color: color-mix(in oklch, var(--primary) 15%, transparent);
 		transform: scale(1.02);
 	}
 
 	:global(.upload-icon) {
 		width: 2.5rem;
 		height: 2.5rem;
-		color: hsl(var(--muted-foreground));
+		color: var(--muted-foreground);
 		transition: transform 0.2s;
 	}
 
 	.dragging :global(.upload-icon) {
 		transform: scale(1.1);
-		color: hsl(var(--primary));
+		color: var(--primary);
 	}
 
 	:global(.upload-icon-success) {
 		width: 2.5rem;
 		height: 2.5rem;
-		color: hsl(var(--primary));
+		color: var(--primary);
 	}
 
 	.upload-placeholder {
 		font-size: 0.8125rem;
-		color: hsl(var(--muted-foreground));
+		color: var(--muted-foreground);
 		text-align: center;
 	}
 
@@ -163,18 +163,18 @@
 
 	.upload-filesize {
 		font-size: 0.75rem;
-		color: hsl(var(--muted-foreground));
+		color: var(--muted-foreground);
 	}
 
 	:global(.upload-icon-success) {
 		width: 3rem;
 		height: 3rem;
-		color: hsl(var(--primary));
+		color: var(--primary);
 	}
 
 	.upload-placeholder {
 		font-size: 0.875rem;
-		color: hsl(var(--muted-foreground));
+		color: var(--muted-foreground);
 	}
 
 	.upload-filename {
@@ -185,7 +185,7 @@
 
 	.upload-filesize {
 		font-size: 0.875rem;
-		color: hsl(var(--muted-foreground));
+		color: var(--muted-foreground);
 	}
 
 	.hidden {


### PR DESCRIPTION
## Summary
- **Root cause:** `FormSelect` and `VideoUploadArea` wrapped design tokens in `hsl(...)`, but `layout.css` defines tokens in `oklch(...)`. The browser silently dropped `hsl(oklch(...))`, so selects fell back to UA-default borders and drop zones rendered with `currentColor`.
- Unwrap `hsl(var(--token))` → `var(--token)`; replace alpha forms with `color-mix(in oklch, ...)`.
- Hide native number-input spinners on the submit form so Age / Height / Weight match the selects visually.
- Add units to `Age (years)` and `Height (ft / in)` labels for parity with `Weight (lbs)`.

## Test plan
- [ ] Visit `/submit` — Sex / Ethnicity / Your Role dropdowns now show the same 1px token-colored border as Age / Height / Weight.
- [ ] Video drop zones show a muted dashed border (not black / text-color).
- [ ] Age / Feet / Inches / Weight inputs no longer show native spinner arrows; typing still works.
- [ ] Labels read "Age (years) *", "Height (ft / in) *", "Weight (lbs) *".
- [ ] Focus ring and error styles on selects still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)