### PR TITLE
Drop red theming from ASD screening results

### DIFF
--- a/igait-frontend/src/lib/components/jobs/JobsDataTable.svelte
+++ b/igait-frontend/src/lib/components/jobs/JobsDataTable.svelte
@@ -82,8 +82,8 @@
 		switch (status.code) {
 			case 'Complete':
 				return {
-					label: status.asd ? 'ASD Detected' : 'No ASD',
-					variant: status.asd ? ('destructive' as const) : ('default' as const)
+					label: status.asd ? 'ASD Indicators' : 'No ASD Indicators',
+					variant: 'secondary' as const
 				};
 			case 'Error':
 				return { label: 'Error', variant: 'destructive' as const };
@@ -159,8 +159,7 @@
 	const selectableFilteredData = $derived(filteredData.filter((j) => !j.approved));
 
 	const allFilteredSelected = $derived(
-		selectableFilteredData.length > 0 &&
-			selectableFilteredData.every((j) => selectedIds.has(j.id))
+		selectableFilteredData.length > 0 && selectableFilteredData.every((j) => selectedIds.has(j.id))
 	);
 
 	function toggleSelectAll() {

--- a/igait-frontend/src/routes/(authenticated)/job/[id]/+page.svelte
+++ b/igait-frontend/src/routes/(authenticated)/job/[id]/+page.svelte
@@ -207,7 +207,7 @@
 	): 'default' | 'secondary' | 'destructive' | 'outline' {
 		switch (status.code) {
 			case 'Complete':
-				return status.asd ? 'destructive' : 'default';
+				return 'secondary';
 			case 'Error':
 				return 'destructive';
 			case 'Processing':


### PR DESCRIPTION
## Summary
- ASD and non-ASD Complete results both render with the neutral \`secondary\` Badge variant instead of \`destructive\`/\`default\`. Red as a pass/fail signal for a neurotype carries a value judgment the tool shouldn't make.
- Relabelled the badges to \"ASD Indicators\" / \"No ASD Indicators\" (was \"ASD Detected\" / \"No ASD\") — framing as screening indicators rather than a verdict, consistent with the existing disclaimer in Footer.svelte.
- Red remains reserved for genuine \`Error\` states.

Touched:
- \`igait-frontend/src/lib/components/jobs/JobsDataTable.svelte\`
- \`igait-frontend/src/routes/(authenticated)/job/[id]/+page.svelte\`

## Test plan
- [ ] Visit \`/submissions\` with at least one Complete ASD-positive and one Complete ASD-negative job — confirm both badges render with the neutral secondary style
- [ ] Visit \`/job/[id]\` for an ASD-positive job — confirm the status badge is no longer red
- [ ] Confirm Error-state jobs still display red

🤖 Generated with [Claude Code](https://claude.com/claude-code)