### PR TITLE
feat: [phase 0] .envrc pulls dev-env from Vaultwarden

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,89 @@
+# .envrc — tracked in git. Pulls the iGait dev-env secret bundle from Vaultwarden
+# (https://vault.igaitapp.com). The old OneDrive-based flow is gone.
+#
+# First-time setup on this machine:
+#   bw config server https://vault.igaitapp.com
+#   bw login                           # interactive: email + master password + 2FA
+#
+# Every shell (or add to your shell rc for persistence):
+#   export BW_SESSION=$(bw unlock --raw)
+#
+# Rotations: when another engineer changes a secret in Vaultwarden, you pick it
+# up on the next shell reload (or `bw sync && direnv reload`).
+
+use flake
+watch_file flake.nix
+
+# ── output helpers ──────────────────────────────────────────────────────────
+# Colors only when stderr is a TTY; keeps CI / pipe consumers clean.
+if [ -t 2 ]; then
+    _C_ERR=$'\033[1;31m'; _C_HINT=$'\033[0;36m'; _C_OK=$'\033[1;32m'; _C_OFF=$'\033[0m'
+else
+    _C_ERR=''; _C_HINT=''; _C_OK=''; _C_OFF=''
+fi
+err()  { printf '%s%s%s\n' "$_C_ERR"  "$*" "$_C_OFF" >&2; }
+hint() { printf '%s%s%s\n' "$_C_HINT" "$*" "$_C_OFF" >&2; }
+ok()   { printf '%s%s%s\n' "$_C_OK"   "$*" "$_C_OFF" >&2; }
+
+# ── prereq: CLI tools on PATH (the flake provides these) ────────────────────
+if ! has bw; then
+    err "ERROR: Bitwarden CLI (bw) not on PATH. Did the Nix dev shell load correctly?"
+    return 1
+fi
+if ! has jq; then
+    err "ERROR: jq not on PATH. Did the Nix dev shell load correctly?"
+    return 1
+fi
+
+# ── prereq: bw state machine ────────────────────────────────────────────────
+# bw status returns JSON with a "status" field: unauthenticated | locked | unlocked.
+# The three branches cover every first-run case we care about.
+BW_STATUS=$(bw status 2>/dev/null | jq -r '.status // "unknown"' 2>/dev/null)
+[ -z "$BW_STATUS" ] && BW_STATUS="unknown"
+
+case "$BW_STATUS" in
+    unauthenticated)
+        err "ERROR: Not logged in to Vaultwarden on this machine."
+        hint "       First-time setup:"
+        hint "         bw config server https://vault.igaitapp.com"
+        hint "         bw login"
+        hint "       Then unlock in your current shell:"
+        hint "         export BW_SESSION=\$(bw unlock --raw)"
+        hint "       Then, reload the shell:"
+        hint "         direnv reload"
+        return 1
+        ;;
+    locked)
+        err "ERROR: Vaultwarden is locked (or BW_SESSION is unset/stale)."
+        hint "       Run:"
+        hint "        export BW_SESSION=\$(bw unlock --raw)"
+        hint "       Then, reload the shell:"
+        hint "         direnv reload"
+        return 1
+        ;;
+    unlocked)
+        : # happy path
+        ;;
+    *)
+        err "ERROR: Unexpected 'bw status' output: '$BW_STATUS'."
+        hint "       Run 'bw status' manually to diagnose."
+        return 1
+        ;;
+esac
+
+# ── fetch and export ────────────────────────────────────────────────────────
+bw sync --quiet 2>/dev/null || true
+
+ITEM_JSON=$(bw get item "igait/dev-env" 2>/dev/null) || {
+    err "ERROR: Could not fetch 'igait/dev-env' from Vaultwarden."
+    hint "       Verify you have read access to the 'igait-niu' organization's"
+    hint "       collection containing the item. Ask @hiibolt for an invite if not."
+    return 1
+}
+
+while IFS=$'\t' read -r name value; do
+    [ -z "$name" ] && continue
+    export "$name=$value"
+done < <(printf '%s' "$ITEM_JSON" | jq -r '.fields[]? | [.name, .value] | @tsv')
+
+ok "iGait env loaded from Vaultwarden."

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ output/*
 
 # Ignore environment/testing things
 .env
-.envrc
+.envrc.local.backup
 batch_process.pbs
 !Cargo.toml
 firebase-debug.log

--- a/README.md
+++ b/README.md
@@ -42,17 +42,26 @@ git clone --recurse-submodules https://github.com/igait-niu/igait.git
 cd igait
 ```
 
-Then, download the `.envrc` and `gcp-key.json` files from "iGait Credentials/Monorepo" in Onedrive. Place `.envrc` in the project root, and `gcp-key.json` at `credentials/gcp-key.json`.
+Then, set up access to secrets. We use [Vaultwarden](https://vault.igaitapp.com) — no more shared dotfiles on OneDrive. Ask @hiibolt for an invite to the `igait-niu` organization if you don't already have one.
 
-If you've correctly hooked your shell with `direnv`, you should see the following:
 ```bash
-direnv: error /home/hiibolt/igait/.envrc is blocked. Run `direnv allow` to approve its content
+# One-time setup on this machine:
+bw config server https://vault.igaitapp.com
+bw login                           # interactive: Vaultwarden email + master password + 2FA
+
+# Every shell (or add to your shell rc for persistence):
+export BW_SESSION=$(bw unlock --raw)
+```
+
+You also need the GCP service-account key. Until that's migrated to Vaultwarden in a later phase, grab `gcp-key.json` from "iGait Credentials/Monorepo" in OneDrive and drop it at `credentials/gcp-key.json`.
+
+If `direnv` is hooked into your shell, entering the repo prints:
+```bash
+direnv: error /home/you/igait/.envrc is blocked. Run `direnv allow` to approve its content
 ```
 ...if not, go back and ensure you installed/hooked correctly.
 
-If you're using WSL2, you may need to normalize `.envrc` from CRLF to LF format. This can be done by selecting the file in Visual Studio Code, clicking the "CRLF" button in the footer panel, and selecting LF instead.
-
-Next, run `direnv allow` as it suggests, and it should automatically download all dependencies, and load all environment variables. Neat, right?
+Run `direnv allow`. The tracked `.envrc` calls `bw get item igait/dev-env` and exports every custom field on that item as an env var in your shell. When another engineer rotates a secret in Vaultwarden, you pick it up on the next shell reload (or explicitly with `bw sync && direnv reload`).
 
 **Optional**:
 I strongly recommend using [Visual Studio Code](https://code.visualstudio.com/) with the Svelte and `rust-analyzer` extensions! 

--- a/flake.nix
+++ b/flake.nix
@@ -43,12 +43,18 @@
                     bun
                     nodejs
 
+                    # Secret fetch for .envrc (pulls igait/dev-env from Vaultwarden)
+                    bitwarden-cli
+                    jq
+
                     # Useful for microservices development
                     ffmpeg  # media-conversion, pose-estimation
                     python  # pose-estimation, cycle-detection, prediction
                 ];
                 shellHook =
                     ''
+                    git submodule init
+                    git submodule update
                     python -m venv .venv
                     source .venv/bin/activate
                     pip install -r ./igait-stages/pose-estimation/igait-mediapipe/requirements.txt


### PR DESCRIPTION
## Summary
- Replaces OneDrive-distributed `.envrc` with a tracked, Vaultwarden-fetching one (`bw get item igait/dev-env`).
- Adds `bitwarden-cli` + `jq` to the flake so the dev shell provides both.
- `.envrc` is keyed on `bw status` (unauthenticated / locked / unlocked) with colorized errors gated on `[ -t 2 ]`.
- `.envrc.local.backup` preserves the old file locally (gitignored).

## Phase-0 scope (per #100)
- **In Vaultwarden `igait/dev-env` (17 custom fields):** 5 secrets + 12 env-scoped config (AWS_*, FIREBASE_ACCESS_KEY, OPENAI_*, VITE_FIREBASE_*, VITE_API_BASE_URL).
- **Excluded (deferred to #101):** `PORT`, `RUST_LOG`, `GOOGLE_APPLICATION_CREDENTIALS`, `TS_RS_EXPORT_DIR`. Rationale recorded in section 6 of #101.
- **Not touched:** no env-var renames, no removal of prod-fallback defaults — that's #101.

## Test plan
- [x] `bw status` = `unauthenticated` → new "First-time setup" error fires with colored output
- [x] `bw status` = `locked` → "Vault locked" error fires
- [x] `bw status` = `unlocked` → all 17 names exported; "iGait env loaded from Vaultwarden." banner shown
- [ ] Fresh clone + `direnv allow` on a teammate's machine loads the same 17 vars

Part of #99. Closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)