### PR TITLE
#101: eliminate prod-fallback defaults (fail loudly on missing config)

### DIFF
--- a/igait-backend/src/helper/database.rs
+++ b/igait-backend/src/helper/database.rs
@@ -34,8 +34,13 @@ impl Database {
     /// * The Firebase access key is the key that allows you to access the Firebase database.
     /// * The Firebase access key should be stored in the system environment as `FIREBASE_ACCESS_KEY`.
     pub async fn init () -> Result<Self> {
+        let url = std::env::var("FIREBASE_RTDB_URL")
+            .context("FIREBASE_RTDB_URL must be set")?;
+        let url = if url.ends_with('/') { url } else { format!("{url}/") };
+        let access_key = std::env::var("FIREBASE_ACCESS_KEY")
+            .context("Missing FIREBASE_ACCESS_KEY! Make sure it's set in your system environment.")?;
         Ok(Self {
-            _state: Firebase::auth("https://network-technology-project-default-rtdb.firebaseio.com/", &std::env::var("FIREBASE_ACCESS_KEY").context("Missing FIREBASE_ACCESS_KEY! Make sure it's set in your system environment.")?)
+            _state: Firebase::auth(&url, &access_key)
                 .map_err(|e| anyhow!("{e:?}"))
                 .context("Couldn't unwrap the URL while trying to initialize the Firebase wrapper class!")?
                 .at("users")

--- a/igait-backend/src/helper/lib.rs
+++ b/igait-backend/src/helper/lib.rs
@@ -478,12 +478,15 @@ impl AppState {
     /// * This function is typically called at the start of the application.
     /// * Required environment variables:
     ///   - `GOOGLE_APPLICATION_CREDENTIALS` - Path to GCP service account JSON
+    ///   - `FIREBASE_PROJECT_ID` - Firebase project identity for token verification
     ///   - `FIREBASE_ACCESS_KEY` - Firebase RTDB access key
     ///   - `OPENAI_ASSISTANT_ID` - OpenAI assistant ID
     ///   - AWS credentials for SES
     pub async fn new() -> Result<Self> {
         let client = Client::new();
-        let firebase_auth = FirebaseAuth::new("network-technology-project").await;
+        let firebase_project_id = std::env::var("FIREBASE_PROJECT_ID")
+            .context("FIREBASE_PROJECT_ID must be set")?;
+        let firebase_auth = FirebaseAuth::new(&firebase_project_id).await;
 
         // Try to initialize the assistant (optional for upload route)
         let assistant = match std::env::var("OPENAI_ASSISTANT_ID") {

--- a/igait-backend/src/main.rs
+++ b/igait-backend/src/main.rs
@@ -14,6 +14,7 @@ use axum::{
 use dotenv::dotenv;
 use helper::lib::{AppState, AppStatePtr};
 use helper::orchestrator::{self, Orchestrator};
+use igait_lib::microservice::{check_env, BACKEND_REQUIRED_ENV};
 use std::sync::Arc;
 use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -41,6 +42,10 @@ async fn main() -> Result<()> {
 
     // Enable loading on WSL
     dotenv().ok();
+
+    // Fail loudly if any required env var is missing — catches misconfiguration
+    // before we start opening clients that would fail one-by-one.
+    check_env(BACKEND_REQUIRED_ENV)?;
 
     // Initialize tracing subscriber with environment filter
     tracing_subscriber::registry()

--- a/igait-frontend/src/lib/api/config.ts
+++ b/igait-frontend/src/lib/api/config.ts
@@ -2,7 +2,11 @@
  * API configuration and base URL
  */
 
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://api.igaitapp.com/api/v1';
+const apiBase = import.meta.env.VITE_API_BASE_URL;
+if (!apiBase) {
+	throw new Error('VITE_API_BASE_URL must be set at build time');
+}
+export const API_BASE_URL: string = apiBase;
 
 export const API_ENDPOINTS = {
 	contribute: `${API_BASE_URL}/contribute`,

--- a/igait-frontend/vite.config.ts
+++ b/igait-frontend/vite.config.ts
@@ -2,6 +2,10 @@ import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
+if (process.env.NODE_ENV === 'production' && !process.env.VITE_API_BASE_URL) {
+	throw new Error('VITE_API_BASE_URL must be set for production build');
+}
+
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
 	server: {

--- a/igait-kubernetes-configs/igait-backend/deployment.yaml
+++ b/igait-kubernetes-configs/igait-backend/deployment.yaml
@@ -29,21 +29,21 @@ spec:
         - containerPort: 3000
           protocol: TCP
         env:
+        # Per-service runtime config (not a shared secret)
         - name: PORT
-          valueFrom:
-            secretKeyRef:
-              name: igait-secrets
-              key: PORT
+          value: "3000"
         - name: RUST_LOG
-          valueFrom:
-            secretKeyRef:
-              name: igait-secrets
-              key: RUST_LOG
+          value: "info"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           valueFrom:
             secretKeyRef:
               name: igait-secrets
               key: GOOGLE_APPLICATION_CREDENTIALS
+        - name: FIREBASE_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: FIREBASE_PROJECT_ID
         - name: FIREBASE_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -54,11 +54,21 @@ spec:
             secretKeyRef:
               name: igait-secrets
               key: FIREBASE_RTDB_URL
-        - name: AWS_S3_BUCKET
+        - name: IGAIT_S3_BUCKET
           valueFrom:
             secretKeyRef:
               name: igait-secrets
-              key: AWS_S3_BUCKET
+              key: IGAIT_S3_BUCKET
+        - name: SES_FROM_ADDRESS
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: SES_FROM_ADDRESS
+        - name: SES_FROM_IDENTITY_ARN
+          valueFrom:
+            secretKeyRef:
+              name: igait-secrets
+              key: SES_FROM_IDENTITY_ARN
         - name: AWS_REGION
           valueFrom:
             secretKeyRef:

--- a/igait-lib/src/microservice/email.rs
+++ b/igait-lib/src/microservice/email.rs
@@ -32,11 +32,9 @@ impl EmailClient {
         let ses_client = SesClient::new(&config);
 
         let from_address = std::env::var("SES_FROM_ADDRESS")
-            .unwrap_or_else(|_| "noreply@igaitapp.com".to_string());
+            .context("SES_FROM_ADDRESS must be set")?;
         let from_identity_arn = std::env::var("SES_FROM_IDENTITY_ARN")
-            .unwrap_or_else(|_| {
-                "arn:aws:ses:us-east-2:851725269484:identity/noreply@igaitapp.com".to_string()
-            });
+            .context("SES_FROM_IDENTITY_ARN must be set")?;
 
         Ok(Self {
             ses_client: Arc::new(Mutex::new(ses_client)),

--- a/igait-lib/src/microservice/mod.rs
+++ b/igait-lib/src/microservice/mod.rs
@@ -32,3 +32,48 @@ pub use retry::*;
 
 #[cfg(feature = "email")]
 pub use email::*;
+
+/// Common env vars every stage worker needs for queue + storage access.
+pub const STAGE_REQUIRED_ENV: &[&str] = &[
+    "FIREBASE_RTDB_URL",
+    "FIREBASE_ACCESS_KEY",
+    "IGAIT_S3_BUCKET",
+    "AWS_REGION",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+];
+
+/// Env vars the finalize stage needs on top of STAGE_REQUIRED_ENV.
+pub const FINALIZE_REQUIRED_ENV: &[&str] = &[
+    "SES_FROM_ADDRESS",
+    "SES_FROM_IDENTITY_ARN",
+];
+
+/// Env vars the backend needs to start.
+pub const BACKEND_REQUIRED_ENV: &[&str] = &[
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "FIREBASE_PROJECT_ID",
+    "FIREBASE_ACCESS_KEY",
+    "FIREBASE_RTDB_URL",
+    "IGAIT_S3_BUCKET",
+    "AWS_REGION",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "SES_FROM_ADDRESS",
+    "SES_FROM_IDENTITY_ARN",
+];
+
+/// Verifies that every env var in `required` is set. Accumulates all
+/// missing names and fails with one error, rather than stopping at the
+/// first. Call this at the very top of `main` so a misconfigured
+/// environment fails loudly before any service client is constructed.
+pub fn check_env(required: &[&str]) -> anyhow::Result<()> {
+    let missing: Vec<&&str> = required
+        .iter()
+        .filter(|v| std::env::var(v).is_err())
+        .collect();
+    if !missing.is_empty() {
+        anyhow::bail!("Missing required env vars: {:?}", missing);
+    }
+    Ok(())
+}

--- a/igait-lib/src/microservice/storage.rs
+++ b/igait-lib/src/microservice/storage.rs
@@ -24,17 +24,17 @@ pub struct StorageConfig {
 
 impl StorageConfig {
     /// Creates a new StorageConfig from environment variables.
-    /// 
+    ///
     /// Reads:
-    /// - `AWS_S3_BUCKET` (defaults to "igait-storage")
-    /// - `AWS_REGION` (defaults to "us-east-2")
+    /// - `IGAIT_S3_BUCKET` — S3 bucket name (required)
+    /// - `AWS_REGION` — AWS region (required; also read by the AWS SDK)
     pub fn from_env() -> Result<Self> {
-        let bucket = std::env::var("AWS_S3_BUCKET")
-            .unwrap_or_else(|_| "igait-storage".to_string());
-        
+        let bucket = std::env::var("IGAIT_S3_BUCKET")
+            .context("IGAIT_S3_BUCKET must be set")?;
+
         let region = std::env::var("AWS_REGION")
-            .unwrap_or_else(|_| "us-east-2".to_string());
-        
+            .context("AWS_REGION must be set")?;
+
         Ok(Self { bucket, region })
     }
 

--- a/igait-lib/src/microservice/worker.rs
+++ b/igait-lib/src/microservice/worker.rs
@@ -61,9 +61,7 @@ impl FirebaseRtdb {
     /// - `FIREBASE_ACCESS_KEY`: The auth token
     pub fn from_env() -> Result<Self> {
         let base_url = std::env::var("FIREBASE_RTDB_URL")
-            .or_else(|_| Ok::<_, std::env::VarError>(
-                "https://network-technology-project-default-rtdb.firebaseio.com".to_string()
-            ))?;
+            .context("FIREBASE_RTDB_URL must be set")?;
         let auth_token = std::env::var("FIREBASE_ACCESS_KEY")
             .context("Missing FIREBASE_ACCESS_KEY environment variable")?;
         

--- a/igait-stages/cycle-detection/src/main.rs
+++ b/igait-stages/cycle-detection/src/main.rs
@@ -8,8 +8,8 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use igait_lib::microservice::{
-    run_stage_job, run_stage_worker, ProcessingResult, QueueItem, StageId, StageWorker,
-    StorageClient,
+    check_env, run_stage_job, run_stage_worker, ProcessingResult, QueueItem, StageId, StageWorker,
+    StorageClient, STAGE_REQUIRED_ENV,
 };
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -291,6 +291,7 @@ async fn run_gait_cycle_detection(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    check_env(STAGE_REQUIRED_ENV)?;
     if std::env::var("IGAIT_JOB_PAYLOAD").is_ok() {
         run_stage_job(CycleDetectionWorker).await
     } else {

--- a/igait-stages/finalize/src/main.rs
+++ b/igait-stages/finalize/src/main.rs
@@ -9,8 +9,9 @@
 
 use anyhow::{Context, Result};
 use igait_lib::microservice::{
-    EmailClient, EmailTemplates, FinalizeQueueItem, JobResult, ProcessingResult, StageId,
-    StorageClient, JobStatus, StageStatus, QueueOps, FirebaseRtdb, job_result_path,
+    check_env, EmailClient, EmailTemplates, FinalizeQueueItem, JobResult, ProcessingResult,
+    StageId, StorageClient, JobStatus, StageStatus, QueueOps, FirebaseRtdb, job_result_path,
+    FINALIZE_REQUIRED_ENV, STAGE_REQUIRED_ENV,
 };
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -318,6 +319,12 @@ impl FinalizeStageWorker {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let required: Vec<&str> = STAGE_REQUIRED_ENV
+        .iter()
+        .chain(FINALIZE_REQUIRED_ENV.iter())
+        .copied()
+        .collect();
+    check_env(&required)?;
     run_finalize_job_mode().await
 }
 

--- a/igait-stages/media-conversion/src/main.rs
+++ b/igait-stages/media-conversion/src/main.rs
@@ -9,8 +9,8 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use igait_lib::microservice::{
-    run_stage_job, run_stage_worker, ProcessingResult, QueueItem, StageId, StageWorker,
-    StorageClient, VideoEditFlags, VideoTransform,
+    check_env, run_stage_job, run_stage_worker, ProcessingResult, QueueItem, StageId, StageWorker,
+    StorageClient, VideoEditFlags, VideoTransform, STAGE_REQUIRED_ENV,
 };
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -289,6 +289,7 @@ async fn standardize_video(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    check_env(STAGE_REQUIRED_ENV)?;
     if std::env::var("IGAIT_JOB_PAYLOAD").is_ok() {
         run_stage_job(MediaConversionWorker).await
     } else {

--- a/igait-stages/pose-estimation/src/main.rs
+++ b/igait-stages/pose-estimation/src/main.rs
@@ -8,8 +8,8 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use igait_lib::microservice::{
-    run_stage_job, run_stage_worker, ProcessingResult, QueueItem, StageId, StageWorker,
-    StorageClient,
+    check_env, run_stage_job, run_stage_worker, ProcessingResult, QueueItem, StageId, StageWorker,
+    StorageClient, STAGE_REQUIRED_ENV,
 };
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -356,6 +356,7 @@ async fn reencode_to_h264(video_path: &PathBuf, logs: &mut String) -> Result<()>
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    check_env(STAGE_REQUIRED_ENV)?;
     if std::env::var("IGAIT_JOB_PAYLOAD").is_ok() {
         run_stage_job(PoseEstimationWorker).await
     } else {

--- a/igait-stages/prediction/src/main.rs
+++ b/igait-stages/prediction/src/main.rs
@@ -8,8 +8,8 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use igait_lib::microservice::{
-    run_stage_job, run_stage_worker, ProcessingResult, QueueItem, StageId, StageWorker,
-    StorageClient,
+    check_env, run_stage_job, run_stage_worker, ProcessingResult, QueueItem, StageId, StageWorker,
+    StorageClient, STAGE_REQUIRED_ENV,
 };
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -232,6 +232,7 @@ impl PredictionWorker {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    check_env(STAGE_REQUIRED_ENV)?;
     if std::env::var("IGAIT_JOB_PAYLOAD").is_ok() {
         run_stage_job(PredictionWorker).await
     } else {

--- a/wiki/environment/VAULTWARDEN.md
+++ b/wiki/environment/VAULTWARDEN.md
@@ -1,0 +1,162 @@
+# Vaultwarden — iGait Secrets
+
+## Purpose
+
+Vaultwarden is iGait's self-hosted, Bitwarden-compatible secret store. It replaced
+an older OneDrive-based `.env` distribution flow. One item — `igait/dev-env` —
+holds every environment variable required to run the dev stack locally. Vaultwarden
+is the source of truth; nobody emails, Slacks, or commits secrets.
+
+- **Instance:** <https://vault.igaitapp.com>
+- **Org / collection:** `igait-niu`
+- **Dev-env item:** `igait/dev-env` (type: Secure Note; values live in `fields[]`)
+- **Access is granted per-engineer** by @hiibolt via the Vaultwarden admin UI.
+
+## First-Time Setup
+
+The `bw` CLI and `jq` are provided by `flake.nix` — you get them automatically
+inside the Nix dev shell.
+
+```bash
+bw config server https://vault.igaitapp.com
+bw login                                  # interactive: email + password + 2FA
+export BW_SESSION=$(bw unlock --raw)      # add to your shell rc for persistence
+direnv allow                              # if not already allowed
+```
+
+From then on, every new shell runs `.envrc`, which fetches the current
+`igait/dev-env` from Vaultwarden and exports every field as an env var.
+
+## How Environment Loading Works
+
+`.envrc` runs on `cd` into the repo (via direnv). The flow:
+
+1. Verify `bw` and `jq` are on `PATH` (from the Nix dev shell).
+2. Check `bw status`:
+   - `unauthenticated` → prompt first-time login
+   - `locked` → prompt `bw unlock` + `BW_SESSION` export
+   - `unlocked` → continue
+3. `bw sync --quiet` to pull the freshest Vaultwarden state.
+4. `bw get item igait/dev-env` → JSON blob.
+5. Iterate `.fields[]` and `export name=value` for each entry.
+6. Print `iGait env loaded from Vaultwarden.`
+
+Rotation: when another engineer updates a field in Vaultwarden, you pick up the
+new value on the next shell reload (`direnv reload`).
+
+### What belongs in `igait/dev-env`
+
+**Yes** — shared secrets and shared environment-scoped config that every engineer
+needs identical. Examples: `FIREBASE_ACCESS_KEY`, `FIREBASE_RTDB_URL`,
+`FIREBASE_PROJECT_ID`, `AWS_ACCESS_KEY_ID`, `IGAIT_S3_BUCKET`,
+`SES_FROM_ADDRESS`.
+
+**No** — per-developer preferences or per-service runtime config:
+
+- `PORT` — each service picks its own; set in `docker-compose.yml` (Phase 2) or K8s
+  Deployment `env:` blocks, not the shared bundle.
+- `RUST_LOG` — tracing-subscriber convention, belongs in your shell rc or
+  `.envrc.local`.
+- Anything personal (editor settings, aliases).
+
+## Adding or Editing Items via CLI
+
+The CLI flow avoids the web UI round-trip and is idempotent.
+
+### Inspect the dev-env item
+
+```bash
+bw sync
+ITEM_ID=$(bw get item igait/dev-env | jq -r .id)
+bw get item "$ITEM_ID" | jq '.fields[] | {name, value}'
+```
+
+### Add or update a field
+
+```bash
+bw get item "$ITEM_ID" \
+  | jq '.fields = (
+      (.fields // [])
+      | map(select(.name != "NEW_VAR_NAME"))       # drop existing if present
+      + [{"name":"NEW_VAR_NAME","value":"the-value","type":0}]
+    )' \
+  | bw encode \
+  | bw edit item "$ITEM_ID"
+
+bw sync                                              # push to server
+direnv reload                                        # re-export into current shell
+```
+
+`type: 0` is a plain (visible) field; `type: 1` is hidden (masked in UI). Prefer
+`1` for secrets.
+
+### Remove a field
+
+```bash
+bw get item "$ITEM_ID" \
+  | jq '.fields |= map(select(.name != "VAR_TO_DROP"))' \
+  | bw encode \
+  | bw edit item "$ITEM_ID"
+
+bw sync
+```
+
+### Rename a field
+
+```bash
+bw get item "$ITEM_ID" \
+  | jq '.fields |= map(if .name == "OLD_NAME" then .name = "NEW_NAME" else . end)' \
+  | bw encode \
+  | bw edit item "$ITEM_ID"
+
+bw sync
+```
+
+### Create a brand-new item
+
+Rare for dev-env, but useful for per-service secrets:
+
+```bash
+bw get template item \
+  | jq '.name = "my-new-item" | .notes = "purpose: ..." | .fields = [
+      {"name":"FOO","value":"bar","type":1}
+    ]' \
+  | bw encode \
+  | bw create item
+```
+
+## Production Secret Flow
+
+Vaultwarden is the **dev** source of truth. Production secrets live in the
+`igait-secrets` Kubernetes Secret in the `igait` namespace — populated out-of-band
+by whoever owns the cluster. The backend Deployment and every orchestrator-spawned
+stage Job consume it via `envFrom: secretRef: igait-secrets`.
+
+When `igait/dev-env` gains a new required key (any new `.context("... must be
+set")?` read added to the Rust code), you **must** also update the cluster
+Secret before the next deploy, or pods crashloop.
+
+```bash
+# Add a single key
+kubectl create secret generic igait-secrets \
+  --namespace igait \
+  --from-literal=NEW_VAR=the-value \
+  --dry-run=client -o yaml \
+  | kubectl apply -f -
+
+# Or patch multiple via JSON Patch (values must be base64)
+kubectl patch secret igait-secrets -n igait --type=json -p='[
+  {"op":"add","path":"/data/NEW_VAR","value":"'"$(echo -n the-value | base64 -w0)"'"},
+  {"op":"remove","path":"/data/OLD_VAR"}
+]'
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `ERROR: Not logged in to Vaultwarden` | `bw config server ...` then `bw login` |
+| `ERROR: Vaultwarden is locked` | `export BW_SESSION=$(bw unlock --raw)` |
+| `ERROR: Could not fetch 'igait/dev-env'` | Ask @hiibolt to grant access to the `igait-niu` collection |
+| Fresh key in Vaultwarden not in shell | `direnv reload` (or `bw sync && direnv reload` if stale) |
+| Pod crashloops after deploy with "VAR must be set" | The cluster `igait-secrets` is missing a key `igait/dev-env` has — mirror it in |


### PR DESCRIPTION
Closes #101 (Phase 1).

## Summary
- **Rust:** replaced every silent `unwrap_or_else(prod_default)` env read with `.context(\"VAR must be set\")?` in `igait-backend` and `igait-lib` (database, worker, storage, email).
- **Renamed** `AWS_S3_BUCKET` → `IGAIT_S3_BUCKET` (AWS-prefix reserved for SDK-controlled vars).
- **Env-ified** the previously-hardcoded Firebase project ID (`network-technology-project`) as new `FIREBASE_PROJECT_ID`.
- **Added** `check_env()` startup helper + `STAGE_REQUIRED_ENV` / `FINALIZE_REQUIRED_ENV` / `BACKEND_REQUIRED_ENV` constants. Every binary's `main` now fails fast with a single error listing *all* missing vars.
- **Frontend:** two-layer guard on `VITE_API_BASE_URL` — runtime throw in `config.ts` + build-time throw in `vite.config.ts` (fails CI in production mode).
- **K8s Deployment:** `PORT` and `RUST_LOG` moved from secretKeyRef to inline `value:` (per-service runtime config, not shared secrets). Added `FIREBASE_PROJECT_ID`, `SES_FROM_ADDRESS`, `SES_FROM_IDENTITY_ARN` secretKeyRefs.
- **Docs:** `wiki/environment/VAULTWARDEN.md` covers dev-env item layout, CLI recipes, and the dev↔prod dual-update requirement.

## Verification
- `cargo build -p igait-backend` clean; all 5 stage crates + `igait-lib` compile.
- `env -i ./target/debug/igait-backend` → `Missing required env vars: [...]` listing all 10 backend requirements. No partial boot.
- `env -i NODE_ENV=production bun run build` → build fails with `VITE_API_BASE_URL must be set for production build`.
- Grep: 0 occurrences of `AWS_S3_BUCKET` or `network-technology-project` outside `.firebaserc`.
- Vaultwarden `igait/dev-env` updated: added the 5 new keys, removed `PORT`/`RUST_LOG`, renamed `AWS_S3_BUCKET` → `IGAIT_S3_BUCKET`.

## ⚠️ Merge-blocker: prod Secret patch required
The prod `igait-secrets` K8s Secret in the `igait` namespace **must** be patched before merge or pods will crashloop with `VAR must be set`. Required changes:
- **Add:** `FIREBASE_PROJECT_ID`, `SES_FROM_ADDRESS`, `SES_FROM_IDENTITY_ARN`
- **Rename:** `AWS_S3_BUCKET` → `IGAIT_S3_BUCKET`
- **Remove:** `PORT`, `RUST_LOG` (now inline in Deployment YAML)

Command pattern documented in `wiki/environment/VAULTWARDEN.md`.

## Out of scope (deferred)
- §3 `docker-compose.yml` fail-loud — file was deleted on master; revisits in Phase 2.
- Phase 2: dev-stack compose reintroduction.

## Test plan
- [ ] CI green (cargo build + vite build both pass with env loaded)
- [ ] `kubectl -n igait get secret igait-secrets -o jsonpath='{.data}' | jq 'keys'` includes all 10 required keys *before* merge
- [ ] Post-merge: backend pod boots without `Missing required env vars` error
- [ ] Post-merge: stage Jobs (media-conversion, pose-estimation, cycle-detection, prediction, finalize) reach Running state on first job submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)