### PR TITLE
feat: Updated Graduate and Undergradute student list in Team Section

### DIFF
--- a/igait-frontend/src/routes/(public)/about/TeamSection.svelte
+++ b/igait-frontend/src/routes/(public)/about/TeamSection.svelte
@@ -13,10 +13,17 @@
 				'Ricardo Torres',
 				'Alicia LaRouech',
 				'Viviana Cortes',
-				'Noelle Veome'
+				'Noelle Veome',
+				'Hope Larson',
+				'Regan Alzueta',
+				'Nico Edwards-Testolin',
+				'Ipsita Priyadarshinee',
+				'Natalie Quinlan',
+				'Harshitha Maartha'
 			],
 			undergrads: [
 				'John White',
+				'Shaivil Patel',
 				'Michael Sensenbrenner',
 				'Luke Ali',
 				'Angelica Sanyal',


### PR DESCRIPTION
Add 6 Grad Students and 1 Undergrad Student to the about us page.

**Grad Students**:
* Noelle Veome
* Hope Larson
* Regan Alzueta
* Nico Edwards-Testolin
* Ipsita Priyadarshinee
* Natalie Quinlan
* Harshitha Maartha

**Undergrad Student**:
* Shaivil Patel