### PR TITLE
#104: Helm chart replaces Kustomize (chart + CI only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,38 @@ jobs:
       - name: Tear down
         if: always()
         run: docker compose down -v
+
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+      - name: helm lint (defaults)
+        run: helm lint charts/igait --set image.tag=sha-ci
+      - name: helm lint (prod values)
+        run: helm lint charts/igait -f charts/igait/values-prod.yaml
+
+  kubeconform:
+    runs-on: ubuntu-latest
+    needs: helm-lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+      - name: Install kubeconform
+        run: |
+          curl -sL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+            | sudo tar xz -C /usr/local/bin kubeconform
+      - name: Render + validate (prod)
+        run: |
+          helm template charts/igait -f charts/igait/values-prod.yaml \
+            | kubeconform -strict -summary -schema-location default \
+              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+      - name: Render + validate (defaults / preview-shaped)
+        run: |
+          helm template charts/igait --set image.tag=sha-ci \
+            | kubeconform -strict -summary -schema-location default \
+              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'

--- a/charts/igait/Chart.yaml
+++ b/charts/igait/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: igait
+description: iGait — web-based autism screening via gait analysis. Backend, frontend, and optional preview-only emulators (Firebase, MinIO, SES-mock).
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.28.0-0"
+home: https://github.com/igait-niu/igait
+sources:
+  - https://github.com/igait-niu/igait
+maintainers:
+  - name: igait-niu
+    url: https://github.com/igait-niu

--- a/charts/igait/templates/NOTES.txt
+++ b/charts/igait/templates/NOTES.txt
@@ -1,0 +1,18 @@
+iGait {{ .Chart.AppVersion }} — release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Backend:  {{ include "igait.fullname" . }}-backend  (port {{ .Values.backend.port }})
+Frontend: {{ include "igait.fullname" . }}-frontend (port {{ .Values.frontend.servicePort }})
+
+{{- if .Values.emulators.firebase.enabled }}
+Preview emulators are ENABLED (firebase, minio, ses). This release is not prod-shaped.
+{{- else }}
+Emulators disabled — talking to real Firebase/AWS/SES.
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+Ingress: https://{{ .Values.ingress.host }}
+{{- else if .Values.tailscale.enabled }}
+Exposure: Tailscale ({{ .Values.tailscale.hostname }}.ts.net)
+{{- else }}
+No external exposure configured.
+{{- end }}

--- a/charts/igait/templates/_helpers.tpl
+++ b/charts/igait/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Standard Helm name/fullname/labels helpers.
+
+`fullname` incorporates `.Release.Name` so per-PR previews (release name
+`igait-pr-42`) don't collide with prod (`igait`). All resources reference
+these so nothing hardcodes the string "igait".
+*/}}
+
+{{- define "igait.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "igait.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "igait.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Standard labels applied to every resource. */}}
+{{- define "igait.labels" -}}
+helm.sh/chart: {{ include "igait.chart" . }}
+{{ include "igait.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/* Base selector labels (stable — never include volatile fields here). */}}
+{{- define "igait.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "igait.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* Resolves image reference for a given component.
+     Usage: {{ include "igait.image" (dict "repo" "igait-backend" "ctx" .) }}
+     ctx.Values.image.registry + / + repo + : + image.tag (or override). */}}
+{{- define "igait.image" -}}
+{{- $repo := .repo -}}
+{{- $registry := .ctx.Values.image.registry -}}
+{{- $tag := .tag | default .ctx.Values.image.tag -}}
+{{- if not $tag -}}
+{{- fail (printf "image.tag must be set (component=%s)" $repo) -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- end -}}

--- a/charts/igait/templates/backend-deployment.yaml
+++ b/charts/igait/templates/backend-deployment.yaml
@@ -1,0 +1,80 @@
+{{- $backendRepo := default "igait-backend" .Values.backend.image.repository -}}
+{{- $tag := default .Values.image.tag .Values.backend.image.tag -}}
+{{- $stages := .Values.backend.stageImages -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "igait.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  revisionHistoryLimit: 1
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "igait.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        {{- include "igait.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      {{- if .Values.backend.rbac.enabled }}
+      serviceAccountName: {{ .Values.backend.serviceAccountName }}
+      {{- end }}
+      containers:
+        - name: igait-backend
+          image: {{ include "igait.image" (dict "repo" $backendRepo "tag" $tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.backend.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.backend.port | quote }}
+            - name: RUST_LOG
+              value: "info"
+            {{- range $key := list "GOOGLE_APPLICATION_CREDENTIALS" "FIREBASE_PROJECT_ID" "FIREBASE_ACCESS_KEY" "FIREBASE_RTDB_URL" "IGAIT_S3_BUCKET" "SES_FROM_ADDRESS" "SES_FROM_IDENTITY_ARN" "AWS_REGION" "AWS_ACCESS_KEY_ID" "AWS_SECRET_ACCESS_KEY" "OPENAI_API_KEY" "OPENAI_ASSISTANT_ID" "OPENAI_VECTOR_STORE_ID" }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.secretName }}
+                  key: {{ $key }}
+            {{- end }}
+            - name: ENABLE_ORCHESTRATOR
+              value: "true"
+            - name: STAGE_MEDIA_CONVERSION_IMAGE
+              value: {{ include "igait.image" (dict "repo" (default "media-conversion" $stages.mediaConversion) "tag" $tag "ctx" .) }}
+            - name: STAGE_POSE_ESTIMATION_IMAGE
+              value: {{ include "igait.image" (dict "repo" (default "pose-estimation" $stages.poseEstimation) "tag" $tag "ctx" .) }}
+            - name: STAGE_CYCLE_DETECTION_IMAGE
+              value: {{ include "igait.image" (dict "repo" (default "cycle-detection" $stages.cycleDetection) "tag" $tag "ctx" .) }}
+            - name: STAGE_PREDICTION_IMAGE
+              value: {{ include "igait.image" (dict "repo" (default "prediction" $stages.prediction) "tag" $tag "ctx" .) }}
+            - name: STAGE_FINALIZE_IMAGE
+              value: {{ include "igait.image" (dict "repo" (default "finalize" $stages.finalize) "tag" $tag "ctx" .) }}
+            {{- with .Values.backend.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+          {{- if .Values.backend.mountGcpKey }}
+          volumeMounts:
+            - name: gcp-key
+              mountPath: /credentials
+              readOnly: true
+          {{- end }}
+      {{- if .Values.backend.mountGcpKey }}
+      volumes:
+        - name: gcp-key
+          secret:
+            secretName: {{ .Values.gcpKeySecretName }}
+      {{- end }}

--- a/charts/igait/templates/backend-rbac.yaml
+++ b/charts/igait/templates/backend-rbac.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.backend.rbac.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.backend.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "igait.fullname" . }}-job-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "igait.fullname" . }}-backend-job-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.backend.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "igait.fullname" . }}-job-manager
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/igait/templates/backend-service.yaml
+++ b/charts/igait/templates/backend-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "igait.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "igait.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+  ports:
+    - name: http
+      port: {{ .Values.backend.port }}
+      targetPort: {{ .Values.backend.port }}
+      protocol: TCP

--- a/charts/igait/templates/firebase-emulator.yaml
+++ b/charts/igait/templates/firebase-emulator.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.emulators.firebase.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "igait.fullname" . }}-firebase-emulator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: firebase-emulator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "igait.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: firebase-emulator
+  template:
+    metadata:
+      labels:
+        {{- include "igait.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: firebase-emulator
+    spec:
+      containers:
+        - name: firebase-emulator
+          image: {{ .Values.emulators.firebase.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.emulators.firebase.rtdbPort }}
+              name: rtdb
+            - containerPort: {{ .Values.emulators.firebase.authPort }}
+              name: auth
+          resources:
+            {{- toYaml .Values.emulators.firebase.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "igait.fullname" . }}-firebase-emulator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: firebase-emulator
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "igait.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: firebase-emulator
+  ports:
+    - name: rtdb
+      port: {{ .Values.emulators.firebase.rtdbPort }}
+      targetPort: {{ .Values.emulators.firebase.rtdbPort }}
+    - name: auth
+      port: {{ .Values.emulators.firebase.authPort }}
+      targetPort: {{ .Values.emulators.firebase.authPort }}
+{{- end }}

--- a/charts/igait/templates/frontend-deployment.yaml
+++ b/charts/igait/templates/frontend-deployment.yaml
@@ -1,0 +1,41 @@
+{{- $frontendRepo := default "igait-frontend" .Values.frontend.image.repository -}}
+{{- $tag := default .Values.image.tag .Values.frontend.image.tag -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "igait.fullname" . }}-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  revisionHistoryLimit: 1
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "igait.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        {{- include "igait.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      containers:
+        - name: igait-frontend
+          image: {{ include "igait.image" (dict "repo" $frontendRepo "tag" $tag "ctx" .) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.frontend.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.frontend.probes.readiness | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.frontend.probes.liveness | nindent 12 }}

--- a/charts/igait/templates/frontend-service.yaml
+++ b/charts/igait/templates/frontend-service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "igait.fullname" . }}-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  {{- if .Values.tailscale.enabled }}
+  annotations:
+    tailscale.com/hostname: {{ .Values.tailscale.hostname | quote }}
+    tailscale.com/tags: "tag:k8s-igait"
+  {{- end }}
+spec:
+  {{- if .Values.tailscale.enabled }}
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  {{- else }}
+  type: ClusterIP
+  {{- end }}
+  selector:
+    {{- include "igait.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  ports:
+    - name: http
+      port: {{ .Values.frontend.servicePort }}
+      targetPort: {{ .Values.frontend.port }}
+      protocol: TCP

--- a/charts/igait/templates/ingress.yaml
+++ b/charts/igait/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "igait.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tlsSecretName | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "igait.fullname" . }}-frontend
+                port:
+                  number: {{ .Values.frontend.servicePort }}
+{{- end }}

--- a/charts/igait/templates/minio.yaml
+++ b/charts/igait/templates/minio.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.emulators.minio.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "igait.fullname" . }}-minio
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "igait.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: minio
+  template:
+    metadata:
+      labels:
+        {{- include "igait.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: minio
+    spec:
+      containers:
+        - name: minio
+          image: {{ .Values.emulators.minio.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - server
+            - /data
+            - --console-address
+            - :{{ .Values.emulators.minio.consolePort }}
+          ports:
+            - containerPort: {{ .Values.emulators.minio.port }}
+              name: api
+            - containerPort: {{ .Values.emulators.minio.consolePort }}
+              name: console
+          env:
+            - name: MINIO_ROOT_USER
+              value: {{ .Values.emulators.minio.rootUser | quote }}
+            - name: MINIO_ROOT_PASSWORD
+              value: {{ .Values.emulators.minio.rootPassword | quote }}
+          resources:
+            {{- toYaml .Values.emulators.minio.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "igait.fullname" . }}-minio
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "igait.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+  ports:
+    - name: api
+      port: {{ .Values.emulators.minio.port }}
+      targetPort: {{ .Values.emulators.minio.port }}
+    - name: console
+      port: {{ .Values.emulators.minio.consolePort }}
+      targetPort: {{ .Values.emulators.minio.consolePort }}
+{{- end }}

--- a/charts/igait/templates/ses-mock.yaml
+++ b/charts/igait/templates/ses-mock.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.emulators.ses.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "igait.fullname" . }}-ses-mock
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ses-mock
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "igait.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ses-mock
+  template:
+    metadata:
+      labels:
+        {{- include "igait.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ses-mock
+    spec:
+      containers:
+        - name: ses-mock
+          image: {{ .Values.emulators.ses.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.emulators.ses.port }}
+              name: http
+          resources:
+            {{- toYaml .Values.emulators.ses.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "igait.fullname" . }}-ses-mock
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "igait.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ses-mock
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "igait.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ses-mock
+  ports:
+    - name: http
+      port: {{ .Values.emulators.ses.port }}
+      targetPort: {{ .Values.emulators.ses.port }}
+{{- end }}

--- a/charts/igait/values-prod.yaml
+++ b/charts/igait/values-prod.yaml
@@ -1,0 +1,30 @@
+# Production overrides. Applied on top of values.yaml by ArgoCD (phase 4)
+# and the promotion workflow (phase 7, which yq-patches image.tag here).
+
+image:
+  # Updated by .github/workflows/promote-to-prod.yml on every promotion.
+  tag: sha-9067bd6
+
+# Prod talks to real Firebase / AWS / SES. No emulators.
+emulators:
+  firebase:
+    enabled: false
+  minio:
+    enabled: false
+  ses:
+    enabled: false
+
+# Prod serves via ingress. Host + TLS wired in phase 10 docs.
+ingress:
+  enabled: false
+
+# Phase 5 will flip this true and wire the ExternalSecret CR.
+externalSecret:
+  enabled: false
+
+backend:
+  replicas: 2
+  mountGcpKey: true
+
+frontend:
+  replicas: 2

--- a/charts/igait/values.yaml
+++ b/charts/igait/values.yaml
@@ -1,0 +1,144 @@
+# Default values for the igait chart.
+# Shape: preview-oriented defaults. values-prod.yaml overrides for production.
+# Per-PR ApplicationSets (phase 6) layer values-preview.yaml + parameters on top.
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  registry: ghcr.io/igait-niu/igait
+  pullPolicy: IfNotPresent
+  # tag is required at render time. Prod sets it in values-prod.yaml; PR
+  # previews set it via ApplicationSet parameter to sha-<head_sha>.
+  tag: ""
+
+# Name of the cluster Secret that holds application credentials
+# (FIREBASE_*, AWS_*, OPENAI_*, SES_*). In prod this is materialised by
+# ExternalSecret (phase 5). In preview envs it is a scoped subset.
+secretName: igait-secrets
+
+# Name of the cluster Secret holding the GCP service-account JSON mounted
+# at /credentials. Prod only; preview emulators don't need it.
+gcpKeySecretName: gcp-key
+
+backend:
+  replicas: 2
+  port: 3000
+  serviceAccountName: igait-backend
+  rbac:
+    # Grants the backend SA permissions to create/observe K8s Jobs. Required
+    # for the per-stage Jobs orchestrator (batch Jobs, pods, pods/log).
+    enabled: true
+  image:
+    # Defaults to <registry>/igait-backend:<image.tag>. Override the whole
+    # repository path here if you need to pin something different.
+    repository: ""
+    tag: ""
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+      ephemeral-storage: 64Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+      ephemeral-storage: 256Mi
+  # Stage images the orchestrator spawns Jobs from. Keys map 1:1 to
+  # STAGE_<UPPER_SNAKE>_IMAGE env vars the backend reads.
+  stageImages:
+    mediaConversion: ""   # defaults to <registry>/media-conversion:<image.tag>
+    poseEstimation: ""
+    cycleDetection: ""
+    prediction: ""
+    finalize: ""
+  # Extra environment variables merged into the backend container. Use for
+  # preview-only plumbing (CORS_ALLOW_ORIGIN, FIREBASE_AUTH_EMULATOR_HOST,
+  # AWS_S3_FORCE_PATH_STYLE, AWS_ENDPOINT_URL_*). Each entry is a full
+  # EnvVar object; raw values or valueFrom are both fine.
+  extraEnv: []
+  # Mount the gcp-key Secret as a file at /credentials. Disable in previews.
+  mountGcpKey: true
+
+frontend:
+  replicas: 2
+  port: 4173
+  servicePort: 80
+  image:
+    repository: ""   # defaults to <registry>/igait-frontend
+    tag: ""
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+      ephemeral-storage: 32Mi
+    limits:
+      cpu: 750m
+      memory: 2Gi
+      ephemeral-storage: 128Mi
+  probes:
+    readiness:
+      httpGet:
+        path: /
+        port: 4173
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    liveness:
+      httpGet:
+        path: /
+        port: 4173
+      initialDelaySeconds: 10
+      periodSeconds: 30
+
+# Preview-only ephemeral services. Prod overrides them all to false.
+emulators:
+  firebase:
+    enabled: true
+    image: ghcr.io/igait-niu/igait/firebase-emulator:latest
+    rtdbPort: 9000
+    authPort: 9099
+    resources:
+      requests: { cpu: 100m, memory: 512Mi }
+      limits:   { cpu: 500m, memory: 1Gi }
+  minio:
+    enabled: true
+    image: minio/minio:latest
+    port: 9000
+    consolePort: 9001
+    rootUser: minioadmin
+    rootPassword: minioadmin
+    resources:
+      requests: { cpu: 50m, memory: 256Mi }
+      limits:   { cpu: 300m, memory: 512Mi }
+  ses:
+    enabled: true
+    image: aws/ses-local:latest
+    port: 8005
+    resources:
+      requests: { cpu: 50m, memory: 128Mi }
+      limits:   { cpu: 200m, memory: 256Mi }
+
+# Prod-only ingress. Disabled by default (previews use Tailscale, phase 6).
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: ""
+  tls: false
+  tlsSecretName: ""
+
+# Phase 5 flips this on. Stub today.
+externalSecret:
+  enabled: false
+
+# Phase 6 flips this on for previews. Stub today.
+tailscale:
+  enabled: false
+  hostname: ""
+
+# Phase 9 fills this in. Stub today.
+probes:
+  enabled: false
+
+# Populated by ApplicationSet when rendering per-PR previews.
+prNumber: ""
+prBranch: ""


### PR DESCRIPTION
## Summary

Phase 4 of the production workflow overhaul (#99). Adds `charts/igait/` to the monorepo and extends `ci.yml` with `helm-lint` + `kubeconform` jobs.

**Scope is deliberately narrow:** chart + CI only. The ArgoCD Application cutover lives in a separate PR against `igait-kubernetes-configs` — per the issue's own implementer note (*\"Don't migrate the ArgoCD Application in the same PR as the chart creation.\"*). Same rationale for the rollback snapshot branch.

## Chart layout

```
charts/igait/
├── Chart.yaml
├── values.yaml              # defaults (preview-shaped)
├── values-prod.yaml         # prod overrides
└── templates/
    ├── _helpers.tpl
    ├── NOTES.txt
    ├── backend-deployment.yaml
    ├── backend-rbac.yaml    # SA + Role + RoleBinding (igait-job-manager)
    ├── backend-service.yaml
    ├── frontend-deployment.yaml
    ├── frontend-service.yaml
    ├── firebase-emulator.yaml  # preview-only, gated
    ├── minio.yaml              # preview-only, gated
    ├── ses-mock.yaml           # preview-only, gated
    └── ingress.yaml            # prod-only, gated
```

## Notable decisions (please sanity-check)

1. **No `stage-deployment.yaml`.** Stages are runtime-spawned K8s Jobs (per the April K8s-Jobs overhaul), not declarative workloads. The `igait-job-manager` Role in `backend-rbac.yaml` is the load-bearing piece for Jobs-mode orchestration. Preview envs (#106) don't need stage Deployments either.
2. **Namespace is NOT in the chart.** ArgoCD creates it via `syncOptions: CreateNamespace=true`. Current kustomize ships a `Namespace` resource; the cutover PR should rely on ArgoCD's flag.
3. **Feature-gate stubs** for Phase 5 (`.Values.externalSecret.enabled`), Phase 6 (`.Values.tailscale.enabled`), Phase 9 (`.Values.probes.enabled`) — all default `false`. Later phases flip the flag.
4. **Backend `extraEnv`** is the extension point for preview-only plumbing (`AWS_S3_FORCE_PATH_STYLE`, `FIREBASE_AUTH_EMULATOR_HOST`, `CORS_ALLOW_ORIGIN`). Stays empty in prod.
5. **Frontend Service** templates out as `ClusterIP` today; when `.Values.tailscale.enabled=true` (preview) it becomes `LoadBalancer` with `loadBalancerClass: tailscale`. Phase 6 wires the rest.

## Parity check (prod render vs current kustomize)

| Resource | kustomize | helm-prod |
|---|---|---|
| Namespace | ✓ | ✗ (ArgoCD handles) |
| SA `igait-backend` | ✓ | ✓ |
| Role `igait-job-manager` | ✓ | ✓ |
| RoleBinding `igait-backend-job-manager` | ✓ | ✓ |
| Service `igait-backend` | ✓ | ✓ |
| Service `igait-frontend` | ✓ | ✓ |
| Deployment `igait-backend` | ✓ | ✓ |
| Deployment `igait-frontend` | ✓ | ✓ |

With release name `igait`, `igait.fullname` collapses to just `igait` — so resource names match kustomize exactly. Labels differ (chart adds standard `app.kubernetes.io/*` + `helm.sh/chart`) — ArgoCD will mark OutOfSync on first apply, as expected per the issue.

## Local validation

- `helm lint charts/igait --set image.tag=sha-ci` — clean
- `helm lint charts/igait -f charts/igait/values-prod.yaml` — clean
- `kubeconform -strict` on both rendered outputs: **20 resources, 0 invalid, 0 errors**

## Done when (from issue)

- [x] `charts/igait/` exists, `helm lint` passes both default + prod
- [x] `kubeconform` reports zero invalid resources
- [x] `helm-lint` + `kubeconform` CI jobs added
- [ ] ArgoCD Application re-pointed → **separate PR in `igait-kubernetes-configs`**
- [ ] `kubectl get -n igait deploy,svc,pvc` parity check → cutover PR
- [ ] Rollback snapshot branch → cutover PR
- [ ] Required on branch protection → requires admin action after merge
- [ ] Production pod restart observed without incident → post-cutover

Closes #104 (chart + CI scope; cutover tracked separately).

## Test plan

- [ ] CI green (`helm-lint` + `kubeconform`)
- [ ] Render `values-prod.yaml` and eyeball vs current kustomize
- [ ] Sanity-check preview render (`--set image.tag=sha-ci`) boots all emulators
- [ ] After merge: add `helm-lint` + `kubeconform` to required branch-protection checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)