### PR TITLE
Fix lost aliases from #121 — use COMPOSE_FILE env var, drop fb wrapper

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -16,7 +16,7 @@
 use flake
 dotenv_if_exists .env
 
-# Compose & Firebase aliases: compose.yml and firebase configs live under
-# infra/, so these wrappers set the -f / --config flags for you.
-alias dc="docker compose -f infra/compose.yml"
-alias fb="firebase --config infra/firebase/firebase.json"
+# Pin `docker compose` at infra/compose.yml without an -f flag every time.
+# Env vars propagate through direnv; aliases don't, so this is the portable
+# fix. Works in interactive shells, CI, Makefiles, everything.
+export COMPOSE_FILE=infra/compose.yml

--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -8,8 +8,10 @@ name: igait
 # design and docs/architecture/stage-execution-modes.md for why stages are
 # long-running services here (worker mode) rather than one-shot K8s Jobs.
 #
-# Usage (alias `dc` is set up by .envrc):
-#   dc up              # equivalent to: docker compose -f infra/compose.yml up
+# Usage:
+#   docker compose up  # .envrc exports COMPOSE_FILE=infra/compose.yml, so
+#                      # bare `docker compose` finds this file from anywhere
+#                      # in the repo. No -f flag needed.
 #
 # Every env var this stack needs is hardcoded against local surrogates
 # (MinIO, ses-mock, Firebase emulator). No .env required. The only


### PR DESCRIPTION
Follow-up to #129 / issue #121.

## Summary

- The \`alias dc=...\` in \`.envrc\` was a silent no-op: direnv propagates env vars to the parent shell but **not** aliases/functions (they bind in the subshell that runs \`.envrc\` and die when it exits).
- Replace with \`export COMPOSE_FILE=infra/compose.yml\`, which \`docker compose\` honours natively. Bare \`docker compose up\` now finds the file from anywhere in the repo — and it works in scripts, Makefiles, and CI, not just interactive shells.
- Drop the \`fb\` wrapper outright. Firebase CLI has no equivalent env var, and it's rarely used locally (the hermetic stack uses the emulator). Devs who need it can \`cd infra/firebase\` or add their own shell alias.

## Test plan

- [x] \`direnv exec . docker compose config --services\` lists all 10 services with no \`-f\` flag
- [ ] Reviewer: after \`direnv allow\`, plain \`docker compose up\` in a fresh shell boots the stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)