### PR TITLE
Make kubectl primary over Tailscale; SSH becomes a cardinal sin

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -20,3 +20,29 @@ dotenv_if_exists .env
 # Env vars propagate through direnv; aliases don't, so this is the portable
 # fix. Works in interactive shells, CI, Makefiles, everything.
 export COMPOSE_FILE=infra/compose.yml
+
+# Prod cluster safety probes. kubectl is configured at the user level
+# (~/.kube/config, context `igait-prod`) — see docs/deployment/cluster.md
+# for the one-time bootstrap. We deliberately don't export KUBECONFIG
+# here: ~/.kube/config is kubectl's default, and overriding it per-repo
+# would fragment behaviour between inside/outside shells and break devs
+# who manage multiple clusters.
+#
+# Two soft checks instead:
+#   1. Is the API reachable? If not, you're probably off Tailscale.
+#   2. Is the current context actually `igait-prod`? Multi-cluster devs
+#      (docker-desktop, minikube, a coworker's dev cluster) may have a
+#      different context active — nudge them before a misfired kubectl
+#      hits the wrong cluster.
+#
+# Neither probe mutates ~/.kube/config. Switching contexts is your call.
+if ! timeout 2 bash -c '</dev/tcp/ai-leads/6443' 2>/dev/null; then
+  echo "⚠️  ai-leads:6443 not reachable — kubectl against prod will fail."
+  echo "    Check Tailscale: \`tailscale status\` (node is 'ai-leads')."
+elif command -v kubectl >/dev/null 2>&1; then
+  ctx=$(kubectl config current-context 2>/dev/null)
+  if [ -n "$ctx" ] && [ "$ctx" != "igait-prod" ]; then
+    echo "ℹ️  kubectl context is '$ctx', not 'igait-prod'."
+    echo "    Switch with: kubectl config use-context igait-prod"
+  fi
+fi

--- a/docs/deployment/cluster.md
+++ b/docs/deployment/cluster.md
@@ -99,6 +99,35 @@ kubectl get application -n argocd -o jsonpath='{range .items[*]}{.metadata.name}
 Any future path restructure PR should include these patch commands in its
 merge checklist — git alone won't update the live cluster.
 
+### Don't `docker login` on the cluster node
+
+Kubelet's credential resolution for image pulls reads, in order: the pod's
+`imagePullSecrets`, the service account's `imagePullSecrets`, then
+`/root/.docker/config.json` on the node (because kubelet runs as root).
+
+If someone `docker login ghcr.io`s on `ai-leads` for a one-off pull, the
+resulting `~/.docker/config.json` becomes a silent node-wide credential
+source for *every* subsequent image pull. When its token expires (GitHub
+`ghs_*` session tokens last hours; even PATs rotate), kubelet keeps sending
+the expired credential — and ghcr returns **403** to invalid creds instead
+of falling back to anonymous. Public packages suddenly fail to pull with
+`failed to fetch oauth token: 403 Forbidden`.
+
+**Don't `docker login` on the node.** If you need to pull a private image:
+
+1. Prefer making the ghcr package public (we do this for every app/stage
+   image — they're binaries, not source).
+2. Otherwise, add an `imagePullSecrets` entry to the Deployment or its
+   ServiceAccount. There's already an unused `ghcr-pull-secret` in the
+   `igait` namespace if you need it.
+
+If someone already did `docker login`, clean it up:
+
+```bash
+ssh root@ai-leads rm /root/.docker/config.json
+ssh root@ai-leads kubectl -n igait delete pods -l app=<affected>
+```
+
 ## Access scope for Claude / agents
 
 SSH access is authorized for:

--- a/docs/deployment/cluster.md
+++ b/docs/deployment/cluster.md
@@ -1,49 +1,112 @@
 # Production Cluster — DGX Spark
 
-## Access
+The iGait prod cluster is a k3s instance on the `ai-leads` DGX Spark box,
+reachable over Tailscale.
 
-The iGait prod cluster is a k3s instance on the `ai-leads` DGX Spark box.
+## Access model — kubectl first, SSH is a cardinal sin
+
+Everything you can do via `kubectl` — reads, restarts, secrets, logs — you
+**must** do via `kubectl`. SSH is reserved for the narrow set of operations
+that modify cluster state at a layer kubectl can't touch (cluster lifecycle,
+node-level configuration). Treat `ssh root@ai-leads` like `rm -rf`: if your
+reflex is to reach for it, stop and check whether kubectl solves it first.
+
+- **Allowed via kubectl** (from your laptop): get/describe/logs/exec,
+  rollout restarts, secret edits, ArgoCD patches, port-forwards, deletes
+  targeted at application resources (pods, jobs, deployments).
+- **Requires SSH** (rare): `k3s` service restarts, node-level filesystem
+  cleanup (e.g., stale `/root/.docker/config.json`), installing/upgrading
+  k3s, touching `/etc/rancher/k3s/*`, `systemctl` anything, inspecting
+  containerd state directly via `crictl`.
+
+If you're unsure which category a task falls into, it's kubectl.
+
+## Bootstrap — wiring up local kubectl
+
+Prerequisite: you're on Tailscale and can reach `ai-leads`. `tailscale status`
+should list it with a `100.x.x.x` IP and no `offline` tag. If not, fix
+Tailscale first — `/onboard` has the setup steps.
+
+Pick the recipe that matches your machine's existing kubeconfig state.
+
+### You have no existing `~/.kube/config` (clean machine)
 
 ```bash
-ssh root@ai-leads
+mkdir -p ~/.kube
+ssh root@ai-leads 'cat /etc/rancher/k3s/k3s.yaml' \
+  | sed 's|server: https://127.0.0.1:6443|server: https://ai-leads:6443|' \
+  > ~/.kube/config
+chmod 600 ~/.kube/config
+kubectl config rename-context default igait-prod
+kubectl config use-context igait-prod
+kubectl get nodes   # should show `ai-leads  Ready  control-plane`
 ```
 
-In order for this to work, you may need to ask the user to run that command interactively in a *separate* shell. `! ssh root@ai-leads` won't work, since auth via Tailscale in the browser is required.
+The sed rewrite matters: k3s writes `server: https://127.0.0.1:6443` by
+default (the file is meant to be read *on* the node). The api-server's TLS
+cert already has `DNS:ai-leads` in its SAN list, so no cert regen needed.
 
-If users don't have access to Tailscale, then they need to prioritize that first. Feel free to refer to the `/onboard` command for more information on how the user should set this up!
+### You already manage other clusters (merge into existing config)
 
-`kubectl` is pre-configured on the host — no kubeconfig juggling needed. From
-there, every namespace is directly reachable.
+Don't overwrite `~/.kube/config` — merge. Kubeconfig merging is first-class:
 
 ```bash
-kubectl version -o json | jq -r .serverVersion.gitVersion    # e.g. v1.34.6+k3s1
-kubectl get ns
-kubectl -n igait get pods
+ssh root@ai-leads 'cat /etc/rancher/k3s/k3s.yaml' \
+  | sed 's|server: https://127.0.0.1:6443|server: https://ai-leads:6443|' \
+  > /tmp/igait-prod.yaml
+# Give the context a unique name so it can't collide with anything you have
+KUBECONFIG=/tmp/igait-prod.yaml kubectl config rename-context default igait-prod
+
+# Merge, then atomically replace
+KUBECONFIG="$HOME/.kube/config:/tmp/igait-prod.yaml" \
+  kubectl config view --flatten > "$HOME/.kube/config.new"
+mv "$HOME/.kube/config.new" "$HOME/.kube/config"
+chmod 600 "$HOME/.kube/config"
+rm /tmp/igait-prod.yaml
+
+kubectl config use-context igait-prod
+kubectl get nodes
 ```
+
+Both recipes land you at the same state: `igait-prod` is a named context
+in `~/.kube/config`, and `kubectl` with no flags talks to the prod cluster.
+
+### What `.envrc` does
+
+The repo's `.envrc` runs two soft probes on `direnv reload`:
+
+1. TCP connect to `ai-leads:6443` — warns if unreachable (likely Tailscale).
+2. Compares `kubectl config current-context` to `igait-prod` — nudges if
+   you're on a different context (docker-desktop, minikube, etc.) so you
+   don't misfire a kubectl against the wrong cluster.
+
+Neither mutates `~/.kube/config`. Context switching stays your call.
 
 ## What lives on the cluster
 
 - **`igait` namespace** — backend Deployment + per-job stage Jobs (spawned
-  dynamically by the orchestrator). Stage Jobs appear on-demand; don't expect
-  to see long-lived stage pods.
-- **`igait-secrets`** (K8s Secret, `igait` ns) — shared runtime config consumed
-  by `envFrom: secretRef` in both the backend Deployment and every stage Job.
-  Dev mirror lives in Vaultwarden as `igait/dev-env`. Keep them in sync — see
-  `docs/environment/vaultwarden.md`.
-- **ArgoCD** — deploys the `infra/k8s/` folder from the monorepo.
-  Pushing to `master` triggers a sync; you generally don't `kubectl apply`
-  YAML directly unless doing an emergency override.
-- **cloudflared** — ingress. External traffic to `igaitapp.com` tunnels through.
-- **GPU** — available to stage Jobs that request it (pose estimation, prediction).
+  dynamically by the orchestrator). Stage Jobs appear on-demand; don't
+  expect to see long-lived stage pods.
+- **`igait-secrets`** (K8s Secret, `igait` ns) — shared runtime config
+  consumed by `envFrom: secretRef` in both the backend Deployment and every
+  stage Job. Dev mirror lives in Vaultwarden as `igait/dev-env`. Keep them
+  in sync — see `docs/environment/vaultwarden.md`.
+- **ArgoCD** — deploys the `infra/k8s/` folder from the monorepo. Pushing
+  to `master` triggers a sync; you generally don't `kubectl apply` YAML
+  directly unless doing an emergency override.
+- **cloudflared** — ingress. External traffic to `igaitapp.com` tunnels
+  through.
+- **GPU** — available to stage Jobs that request it (pose estimation,
+  prediction).
 
-## Common ops recipes
+## Common ops recipes (all kubectl, all from your laptop)
 
 ### Watch a rollout
 
 ```bash
-kubectl rollout restart deployment/apps/backend -n igait
-kubectl rollout status deployment/apps/backend -n igait --timeout=3m
-kubectl logs -n igait -l app=apps/backend --tail=50 --prefix=true
+kubectl rollout restart deployment/backend -n igait
+kubectl rollout status deployment/backend -n igait --timeout=3m
+kubectl logs -n igait -l app=backend --tail=50 --prefix=true
 ```
 
 ### Tail live stage Jobs for a running pipeline
@@ -63,20 +126,19 @@ kubectl -n igait get secret igait-secrets -o jsonpath='{.data}' | jq 'keys'
 
 ### Re-point ArgoCD apps after a path restructure
 
-ArgoCD `Application` resources store `spec.source.path` in the cluster, not
-git. When a monorepo restructure moves `infra/k8s/**` (or the ArgoCD apps
-folder itself), the deployed Applications still point at the *old* path even
-after git is updated — you'll see `ComparisonError: app path does not exist`
-in the UI.
+ArgoCD `Application` resources store `spec.source.path` in the cluster,
+not git. When a monorepo restructure moves `infra/k8s/**` (or the ArgoCD
+apps folder itself), the deployed Applications still point at the *old*
+path even after git is updated — you'll see `ComparisonError: app path
+does not exist` in the UI.
 
 The `app-of-apps` pattern *cannot* self-heal this: if its current `path`
 points nowhere, it can't read the new manifest for itself.
 
-**Fix:** patch every affected Application once via `kubectl`, then let
+**Fix:** patch every affected Application once via kubectl, then let
 selfHeal take over again.
 
 ```bash
-ssh root@ai-leads 'bash -s' <<'REMOTE'
 patch() {
   kubectl -n argocd patch application "$1" --type=merge \
     -p "{\"spec\":{\"source\":{\"path\":\"$2\"}}}"
@@ -87,7 +149,6 @@ patch app-of-apps  infra/k8s/argocd/apps
 patch cloudflared  infra/k8s/cloudflared
 patch igait        infra/k8s
 patch vaultwarden  infra/k8s/vaultwarden
-REMOTE
 ```
 
 Survey afterwards — every Git-sourced app should be `Synced`:
@@ -99,6 +160,8 @@ kubectl get application -n argocd -o jsonpath='{range .items[*]}{.metadata.name}
 Any future path restructure PR should include these patch commands in its
 merge checklist — git alone won't update the live cluster.
 
+## SSH-only recipes (the rare, cluster-modifying ones)
+
 ### Don't `docker login` on the cluster node
 
 Kubelet's credential resolution for image pulls reads, in order: the pod's
@@ -108,10 +171,10 @@ Kubelet's credential resolution for image pulls reads, in order: the pod's
 If someone `docker login ghcr.io`s on `ai-leads` for a one-off pull, the
 resulting `~/.docker/config.json` becomes a silent node-wide credential
 source for *every* subsequent image pull. When its token expires (GitHub
-`ghs_*` session tokens last hours; even PATs rotate), kubelet keeps sending
-the expired credential — and ghcr returns **403** to invalid creds instead
-of falling back to anonymous. Public packages suddenly fail to pull with
-`failed to fetch oauth token: 403 Forbidden`.
+`ghs_*` session tokens last hours; even PATs rotate), kubelet keeps
+sending the expired credential — and ghcr returns **403** to invalid
+creds instead of falling back to anonymous. Public packages suddenly fail
+to pull with `failed to fetch oauth token: 403 Forbidden`.
 
 **Don't `docker login` on the node.** If you need to pull a private image:
 
@@ -121,21 +184,29 @@ of falling back to anonymous. Public packages suddenly fail to pull with
    ServiceAccount. There's already an unused `ghcr-pull-secret` in the
    `igait` namespace if you need it.
 
-If someone already did `docker login`, clean it up:
+If someone already did `docker login`, clean it up (this is one of the
+few legitimate SSH uses — it's a node-level filesystem mutation, no
+kubectl equivalent):
 
 ```bash
 ssh root@ai-leads rm /root/.docker/config.json
-ssh root@ai-leads kubectl -n igait delete pods -l app=<affected>
+kubectl -n igait delete pods -l app=<affected>   # kubectl, not ssh
 ```
 
 ## Access scope for Claude / agents
 
-SSH access is authorized for:
-- Inspecting/editing `igait-secrets` in the `igait` namespace
-- Rollout-restarting `apps/backend` and reading pod logs
-- Running non-destructive `kubectl get` / `describe` / `logs` against the
-  `igait` namespace
+kubectl access (from an agent's shell, now that the local kubeconfig is
+wired) is authorized for:
+- Read-only inspection of the `igait` namespace (get/describe/logs).
+- Rollout-restarting `backend` and reading pod logs.
+- Editing `igait-secrets` when explicitly asked.
+- ArgoCD `Application` patches when explicitly asked.
 
-Anything beyond that scope — node-level commands, other namespaces, destructive
-deletions, cluster-wide changes — should be explicitly confirmed by @hiibolt
-first.
+SSH access — because of the cardinal-sin framing — requires explicit
+confirmation from @hiibolt for every invocation, even when the task falls
+under "SSH-only recipes" above. The agent should propose the command and
+wait for green-light, not execute blindly.
+
+Anything beyond that scope — cluster-wide changes, destructive deletions,
+node-level commands, other namespaces — should be explicitly confirmed by
+@hiibolt first regardless of which tool (kubectl or ssh) would be used.


### PR DESCRIPTION
## Summary

kubectl was previously only configured on the cluster node itself, which meant every read-only check (`kubectl get pods`, logs, describes) had to round-trip through `ssh root@ai-leads`. That's a footgun — SSH gives shell access to a prod node for operations kubectl should handle.

- **Local kubectl over Tailscale.** Bootstrap recipes added for both clean machines and multi-cluster devs (merges into existing `~/.kube/config` rather than clobbering). The k3s API cert already includes `DNS:ai-leads` in its SANs — no cert regen needed. Context is named `igait-prod`.
- **`.envrc` soft probes.** Two non-mutating checks on `direnv reload`: TCP reachability of `ai-leads:6443` (flags Tailscale issues) and a current-context mismatch nudge. Neither mutates `~/.kube/config` — context switching stays the user's call, important for devs who also run docker-desktop/minikube/etc.
- **Docs reframed around "kubectl first, SSH is a cardinal sin."** `docs/deployment/cluster.md` now splits recipes into kubectl-from-your-laptop (the vast majority) vs SSH-only (k3s lifecycle, node FS cleanup, containerd poking). Agent access scope requires explicit green-light for every SSH call.
- **Incident-driven doc: don't `docker login` on the node.** Today's backend-ImagePullBackOff was caused by a 16-day-old `ghs_*` session token in `/root/.docker/config.json` that kubelet kept sending to ghcr, which then returned 403 on a *public* package. Documented the failure mode and cleanup procedure.

## Test plan

- [x] `kubectl get nodes` from laptop → `ai-leads Ready control-plane v1.34.6+k3s1`
- [x] `direnv reload` runs clean when cluster reachable + context is `igait-prod`
- [x] `.envrc` probes use only `bash` builtins (`/dev/tcp`, `timeout`) — no new tool dependencies
- [x] CI green
- [x] Another dev tries the "merge into existing config" recipe to confirm it doesn't clobber their existing contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)