### PR TITLE
Drain rollouts cleanly: /healthz, probes, preStop, 180s grace

### DIFF
--- a/apps/backend/src/main.rs
+++ b/apps/backend/src/main.rs
@@ -144,6 +144,7 @@ async fn main() -> Result<()> {
 
     // Nest the API into the general app router
     let mut app = Router::new()
+        .route("/healthz", get(|| async { "ok" }))
         .nest("/api/v1", api_v1)
         .nest("/api/internal", api_internal)
         .layer(DefaultBodyLimit::max(500000000));

--- a/infra/k8s/backend/deployment.yaml
+++ b/infra/k8s/backend/deployment.yaml
@@ -22,12 +22,52 @@ spec:
         app: backend
     spec:
       serviceAccountName: backend
+      # Upload requests can be multi-MB multipart streams that take tens of
+      # seconds over a residential uplink. Axum's `.with_graceful_shutdown`
+      # lets in-flight requests finish after SIGTERM; kubelet enforces the
+      # outer deadline. 180s covers a typical front+side video pair with
+      # headroom. Default 30s truncates uploads mid-stream → 502 at the edge.
+      terminationGracePeriodSeconds: 180
       containers:
       - image: ghcr.io/igait-niu/igait/backend:sha-81f77a6
         name: backend
         ports:
         - containerPort: 3000
           protocol: TCP
+        # Readiness gates rollout traffic: the pod is only added to the
+        # Service endpoints once /healthz returns 200. Without this the pod
+        # is "Ready" the instant the container starts, which races ahead of
+        # the axum listener binding. Failures also deregister the pod from
+        # the Service without killing it — useful for transient unhealthy
+        # states that shouldn't trigger a restart loop.
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 3000
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+        # Liveness is more conservative than readiness: a failure restarts
+        # the pod, so we want high tolerance to avoid flapping during slow
+        # GC pauses, disk stalls, or upstream hiccups that block the async
+        # runtime briefly.
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 6
+        # Give the Endpoints controller time to deregister this pod from the
+        # Service before the process stops accepting connections. Without it,
+        # cloudflared (and any other client) can still route new requests to
+        # a terminating pod for ~1–2s → connection refused races.
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep", "5"]
         env:
         # Per-service runtime config (not a shared secret)
         - name: PORT


### PR DESCRIPTION
## Summary

Prod was returning Cloudflare 502s to users submitting gait videos during backend rollouts. Root cause: in-flight multipart uploads were being killed by SIGKILL because the default 30s `terminationGracePeriodSeconds` is shorter than a typical video-pair upload over a home uplink. Axum's existing `.with_graceful_shutdown` already lets in-flight request futures complete after SIGTERM — the missing pieces were all at the k8s lifecycle layer.

- **`/healthz`** — root-level, unauthenticated, no state. Infra probe endpoint distinct from product `/api/v1`.
- **readinessProbe** — gates rollout traffic onto new pods only once axum is actually listening (closes the "pod is Ready but listener hasn't bound yet" race).
- **livenessProbe** — conservative thresholds (2 min to restart) to avoid flapping on transient runtime stalls.
- **`preStop: sleep 5`** — lets the Endpoints controller deregister the pod before axum stops accepting, closing the deregistration-propagation race in the other direction.
- **`terminationGracePeriodSeconds: 180`** — covers realistic upload durations before SIGKILL. Axum's graceful-shutdown future has no internal deadline, so this is the real cap on how long an in-flight request gets to finish.

Why both probes + preStop + grace: readiness brings traffic **in** cleanly on the new pod, preStop drains traffic **out** cleanly from the old pod, and the bumped grace period ensures in-flight uploads actually get to finish inside that drain window.

CI `sed` patches for image tags target `image:`/`value:` lines specifically; the new `lifecycle`/`readinessProbe`/`livenessProbe` blocks have no image lines and won't be touched by deploy workflows.

## Test plan

- [x] `cargo check -p backend` clean
- [x] `cargo fmt --check -p backend` clean
- [x] Local stack `/healthz` returns `200 ok`
- [x] Local stack regression: full 44MB multipart upload (`Su_215_F_10_0_58.MOV` + `Su_215_S_10_0_58.MOV`) returns 200
- [x] lefthook (rust-fmt, rust-clippy, rust-test) passing on pre-push
- [ ] After merge: watch next backend rollout on prod for clean pod handoff (no cloudflared `broken pipe` entries around the rollout window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)