### PR TITLE
Rename default branch: master -> main

### DIFF
--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -133,8 +133,8 @@ The `item-add` command returns JSON with the item ID when `--format json` is use
 
 | Operation | Command |
 |-----------|---------|
-| Create branch | `git checkout -b <branch-name> master && git push -u origin <branch-name>` |
-| Create PR | `gh pr create --repo igait-niu/igait --title "..." --body "..." --base master --head <branch>` |
+| Create branch | `git checkout -b <branch-name> main && git push -u origin <branch-name>` |
+| Create PR | `gh pr create --repo igait-niu/igait --title "..." --body "..." --base main --head <branch>` |
 | Get PR | `gh pr view <N> --repo igait-niu/igait` |
 | Get PR (JSON) | `gh pr view <N> --repo igait-niu/igait --json title,body,state,files,reviews,comments,statusCheckRollup` |
 | PR changed files | `gh pr diff <N> --repo igait-niu/igait` |
@@ -172,7 +172,7 @@ For non-creation operations, skip the interview. Just do the thing and confirm.
 - **Move item to a column**: use the Status field ID and option ID from the Board Fields table, then call `item-edit`
   - **Special: moving to "In progress"** — when an item moves to In progress, also:
     1. **Assign the issue**: `gh issue edit <N> --repo igait-niu/igait --add-assignee hiibolt` (if not already assigned).
-    2. **Create a feature branch**: `git checkout -b <issue-number>-<short-description> master && git push -u origin <branch>`. Skip if a branch for this issue already exists.
+    2. **Create a feature branch**: `git checkout -b <issue-number>-<short-description> main && git push -u origin <branch>`. Skip if a branch for this issue already exists.
     3. **Link branch to issue**: `gh issue comment <N> --repo igait-niu/igait --body '**[Started]** Working on branch \`<branch-name>\`'`
     4. **Confirm** with: the new status, assignee, and branch name so the user can `git fetch && git checkout` immediately.
 - **Change priority/size**: use the field IDs and option IDs from the Board Fields table, then call `item-edit`
@@ -180,8 +180,8 @@ For non-creation operations, skip the interview. Just do the thing and confirm.
 - **Archive item**: `gh project item-archive 2 --owner igait-niu --id <item-id>`
 
 ### Branch & PR Operations
-- **Create branch for issue**: use pattern `<issue-number>-<short-description>`. All issue work must happen on a feature branch, never directly on `master`.
-- **Create PR**: `gh pr create` — set title, body, head branch, base branch (`master`). Always include `Closes #<issue-number>` in the PR body so GitHub auto-links and auto-closes the issue on merge. After creation, add to the project board via `gh project item-add` and set Status to "In review" using the hardcoded field IDs.
+- **Create branch for issue**: use pattern `<issue-number>-<short-description>`. All issue work must happen on a feature branch, never directly on `main`.
+- **Create PR**: `gh pr create` — set title, body, head branch, base branch (`main`). Always include `Closes #<issue-number>` in the PR body so GitHub auto-links and auto-closes the issue on merge. After creation, add to the project board via `gh project item-add` and set Status to "In review" using the hardcoded field IDs.
 - **Check PR status**: `gh pr view` or `gh pr checks`
 - **Review PR**: `gh pr diff` to see changes, then `gh pr review`
 - **Merge PR**: `gh pr merge` — confirm merge method with user first. Do **not** auto-set the board status to "Done" — leave that for the user or a separate explicit action.

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -2,7 +2,7 @@ name: Build Backend
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
     paths:
       - 'apps/backend/**'
       - 'apps/shared/**'
@@ -71,12 +71,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
           for i in 1 2 3 4 5; do
-            git fetch origin master
-            git reset --hard origin/master
+            git fetch origin main
+            git reset --hard origin/main
             sed -i "s|image: ghcr.io/igait-niu/igait/backend:.*|image: ghcr.io/igait-niu/igait/backend:sha-${SHA_SHORT}|" infra/k8s/backend/deployment.yaml
             git add infra/k8s/
             git diff --cached --quiet && echo "Already up to date" && exit 0
             git commit -m "deploy: backend:sha-${SHA_SHORT}"
-            git push origin master && exit 0
+            git push origin main && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-cycle-detection.yml
+++ b/.github/workflows/build-cycle-detection.yml
@@ -2,7 +2,7 @@ name: Build Cycle Detection
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
     paths:
       - 'apps/stages/cycle-detection/**'
       - 'apps/shared/**'
@@ -73,12 +73,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
           for i in 1 2 3 4 5; do
-            git fetch origin master
-            git reset --hard origin/master
+            git fetch origin main
+            git reset --hard origin/main
             sed -i "s|value: ghcr.io/igait-niu/igait/cycle-detection:.*|value: ghcr.io/igait-niu/igait/cycle-detection:sha-${SHA_SHORT}|" infra/k8s/backend/deployment.yaml
             git add infra/k8s/
             git diff --cached --quiet && echo "Already up to date" && exit 0
             git commit -m "deploy: cycle-detection:sha-${SHA_SHORT}"
-            git push origin master && exit 0
+            git push origin main && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-finalize.yml
+++ b/.github/workflows/build-finalize.yml
@@ -2,7 +2,7 @@ name: Build Finalize
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
     paths:
       - 'apps/stages/finalize/**'
       - 'apps/shared/**'
@@ -71,12 +71,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
           for i in 1 2 3 4 5; do
-            git fetch origin master
-            git reset --hard origin/master
+            git fetch origin main
+            git reset --hard origin/main
             sed -i "s|value: ghcr.io/igait-niu/igait/finalize:.*|value: ghcr.io/igait-niu/igait/finalize:sha-${SHA_SHORT}|" infra/k8s/backend/deployment.yaml
             git add infra/k8s/
             git diff --cached --quiet && echo "Already up to date" && exit 0
             git commit -m "deploy: finalize:sha-${SHA_SHORT}"
-            git push origin master && exit 0
+            git push origin main && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-media-conversion.yml
+++ b/.github/workflows/build-media-conversion.yml
@@ -2,7 +2,7 @@ name: Build Media Conversion
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
     paths:
       - 'apps/stages/media-conversion/**'
       - 'apps/shared/**'
@@ -71,12 +71,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
           for i in 1 2 3 4 5; do
-            git fetch origin master
-            git reset --hard origin/master
+            git fetch origin main
+            git reset --hard origin/main
             sed -i "s|value: ghcr.io/igait-niu/igait/media-conversion:.*|value: ghcr.io/igait-niu/igait/media-conversion:sha-${SHA_SHORT}|" infra/k8s/backend/deployment.yaml
             git add infra/k8s/
             git diff --cached --quiet && echo "Already up to date" && exit 0
             git commit -m "deploy: media-conversion:sha-${SHA_SHORT}"
-            git push origin master && exit 0
+            git push origin main && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-pose-estimation.yml
+++ b/.github/workflows/build-pose-estimation.yml
@@ -2,7 +2,7 @@ name: Build Pose Estimation
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
     paths:
       - 'apps/stages/pose-estimation/**'
       - 'apps/shared/**'
@@ -73,12 +73,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
           for i in 1 2 3 4 5; do
-            git fetch origin master
-            git reset --hard origin/master
+            git fetch origin main
+            git reset --hard origin/main
             sed -i "s|value: ghcr.io/igait-niu/igait/pose-estimation:.*|value: ghcr.io/igait-niu/igait/pose-estimation:sha-${SHA_SHORT}|" infra/k8s/backend/deployment.yaml
             git add infra/k8s/
             git diff --cached --quiet && echo "Already up to date" && exit 0
             git commit -m "deploy: pose-estimation:sha-${SHA_SHORT}"
-            git push origin master && exit 0
+            git push origin main && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-prediction.yml
+++ b/.github/workflows/build-prediction.yml
@@ -2,7 +2,7 @@ name: Build Prediction
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
     paths:
       - 'apps/stages/prediction/**'
       - 'apps/shared/**'
@@ -73,12 +73,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
           for i in 1 2 3 4 5; do
-            git fetch origin master
-            git reset --hard origin/master
+            git fetch origin main
+            git reset --hard origin/main
             sed -i "s|value: ghcr.io/igait-niu/igait/prediction:.*|value: ghcr.io/igait-niu/igait/prediction:sha-${SHA_SHORT}|" infra/k8s/backend/deployment.yaml
             git add infra/k8s/
             git diff --cached --quiet && echo "Already up to date" && exit 0
             git commit -m "deploy: prediction:sha-${SHA_SHORT}"
-            git push origin master && exit 0
+            git push origin main && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -2,7 +2,7 @@ name: Build Web Frontend
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
     paths:
       - 'apps/frontend/**'
       - 'infra/docker/frontend/**'
@@ -79,12 +79,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin git@github.com:igait-niu/igait.git
           for i in 1 2 3 4 5; do
-            git fetch origin master
-            git reset --hard origin/master
+            git fetch origin main
+            git reset --hard origin/main
             sed -i "s|image: ghcr.io/igait-niu/igait/frontend:.*|image: ghcr.io/igait-niu/igait/frontend:sha-${SHA_SHORT}|" infra/k8s/frontend/deployment.yaml
             git add infra/k8s/
             git diff --cached --quiet && echo "Already up to date" && exit 0
             git commit -m "deploy: frontend:sha-${SHA_SHORT}"
-            git push origin master && exit 0
+            git push origin main && exit 0
           done
           echo "Failed to push after 5 attempts" && exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
     # Skip on pushes that only touch K8s manifests — those are produced by
     # the `github-actions[bot]` image-tag bumps after each build-*.yml run
     # (commit messages like `deploy: backend:sha-...`), and they don't

--- a/docs/deployment/cluster.md
+++ b/docs/deployment/cluster.md
@@ -92,7 +92,7 @@ Neither mutates `~/.kube/config`. Context switching stays your call.
   stage Job. Dev mirror lives in Vaultwarden as `igait/dev-env`. Keep them
   in sync — see `docs/environment/vaultwarden.md`.
 - **ArgoCD** — deploys the `infra/k8s/` folder from the monorepo. Pushing
-  to `master` triggers a sync; you generally don't `kubectl apply` YAML
+  to `main` triggers a sync; you generally don't `kubectl apply` YAML
   directly unless doing an emergency override.
 - **cloudflared** — ingress. External traffic to `igaitapp.com` tunnels
   through.

--- a/infra/k8s/argocd/apps/app-of-apps.yaml
+++ b/infra/k8s/argocd/apps/app-of-apps.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/igait-niu/igait.git
-    targetRevision: master
+    targetRevision: main
     path: infra/k8s/argocd/apps
     directory:
       recurse: false

--- a/infra/k8s/argocd/apps/cloudflared.yaml
+++ b/infra/k8s/argocd/apps/cloudflared.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/igait-niu/igait.git
-    targetRevision: master
+    targetRevision: main
     path: infra/k8s/cloudflared
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/argocd/apps/igait.yaml
+++ b/infra/k8s/argocd/apps/igait.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/igait-niu/igait.git
-    targetRevision: master
+    targetRevision: main
     path: infra/k8s
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/argocd/apps/vaultwarden.yaml
+++ b/infra/k8s/argocd/apps/vaultwarden.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/igait-niu/igait.git
-    targetRevision: master
+    targetRevision: main
     path: infra/k8s/vaultwarden
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k8s/backend/deployment.yaml
+++ b/infra/k8s/backend/deployment.yaml
@@ -145,7 +145,7 @@ spec:
         # Stage container images (updated by CI/CD). Env var keys are
         # STAGE_<UPPER_SNAKE_KEY>_IMAGE; values track the ghcr image
         # tag for each stage and are sed-patched by the per-stage
-        # build workflows on every push to master.
+        # build workflows on every push to main.
         - name: STAGE_MEDIA_CONVERSION_IMAGE
           value: ghcr.io/igait-niu/igait/media-conversion:sha-e530730
         - name: STAGE_POSE_ESTIMATION_IMAGE


### PR DESCRIPTION
## Summary
- Flips CI workflow triggers (`branches: ['master']` + self-push `git push origin master`) to `main`
- Updates ArgoCD `targetRevision: master` -> `main` across app-of-apps + 3 child Applications
- Updates docs and github skill references

Committed to master first so ArgoCD's app-of-apps reconciliation picks up the new `targetRevision: main` on child Applications **before** the `master` branch is deleted. After merge:

1. Create `main` from updated master
2. Flip repo default to `main`
3. Update/delete ruleset #14801991 to target `main`
4. Delete remote `master`

## Test plan
- [ ] ArgoCD app-of-apps sync shows child Applications reading from `main` post-merge
- [ ] Next push to `main` triggers build workflows