### PR TITLE
Fix app-of-apps permanent OutOfSync drift

### DIFF
--- a/infra/k8s/argocd/apps/app-of-apps.yaml
+++ b/infra/k8s/argocd/apps/app-of-apps.yaml
@@ -9,8 +9,6 @@ spec:
     repoURL: https://github.com/igait-niu/igait.git
     targetRevision: main
     path: infra/k8s/argocd/apps
-    directory:
-      recurse: false
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd


### PR DESCRIPTION
## Summary
- Remove \`source.directory.recurse: false\` from \`app-of-apps.yaml\`

## Why
ArgoCD's controller normalizes defaulted fields out of live Application specs. \`recurse: false\` is the default for directory-type sources, so it gets stripped on every reconcile. The manifest in git spells it out explicitly, so every diff reports the field as missing live — producing a permanent \`OutOfSync\` that \`selfHeal: true\` can't resolve (it reapplies the field; the controller strips it again).

Matches the normalized form and ends the drift loop. No functional change — \`recurse: false\` remains the effective behavior either way.

## Test plan
- [ ] Post-merge: \`kubectl -n argocd get application app-of-apps\` shows \`Synced\`