### PR TITLE
#105: wire ESO + AWS SSM Parameter Store + Tailscale Operator

### DIFF
--- a/docs/deployment/external-secrets.md
+++ b/docs/deployment/external-secrets.md
@@ -150,9 +150,80 @@ kubectl -n igait get secret igait-secrets \
 | `/igait/prod/env/OPENAI_ASSISTANT_ID` | `igait-secrets.OPENAI_ASSISTANT_ID` |
 | `/igait/prod/env/OPENAI_VECTOR_STORE_ID` | `igait-secrets.OPENAI_VECTOR_STORE_ID` |
 | `/igait/prod/gcp-key/key.json` | `gcp-key.gcp-key.json` |
+| `/igait/prod/tailscale/client_id` | `operator-oauth.client_id` (ns: `tailscale`) |
+| `/igait/prod/tailscale/client_secret` | `operator-oauth.client_secret` (ns: `tailscale`) |
 
 To add a new secret: put it in SSM under `/igait/prod/env/` and it'll appear
 in `igait-secrets` on the next refresh — the `dataFrom: find:` selector in
 `infra/k8s/backend/external-secrets.yaml` auto-discovers everything under
 that path. Then add a `secretKeyRef` entry in the backend deployment to
 surface it as an env var.
+
+## Tailscale Operator
+
+The Tailscale Operator is installed via Helm (ArgoCD App:
+`tailscale-operator`) and its OAuth credentials are supplied by ESO, not
+by the chart's values. The flow:
+
+1. `tailscale-operator-config` App (sync-wave `-1`) creates the
+   `tailscale` namespace and the `ExternalSecret` targeting
+   `operator-oauth`.
+2. ESO materializes `operator-oauth` in the `tailscale` namespace with
+   keys `client_id` / `client_secret` from SSM.
+3. `tailscale-operator` App (sync-wave `0`) installs the Helm chart.
+   Chart values leave `oauth.clientId` / `oauth.clientSecret` empty —
+   the chart's conditional Secret template skips creation, and the
+   Operator Deployment picks up our ESO-managed `operator-oauth` via
+   `secretKeyRef`.
+
+### Tag hierarchy
+
+Two tags, owned correctly:
+
+- `tag:k8s-igait-operator` — the Operator pod registers itself with
+  this tag. Self-owned so only devices already bearing it can mint new
+  auth keys for it (bootstrap capability).
+- `tag:k8s-igait` — assigned by the Operator to the workload devices
+  it spawns (exposed Services, Ingresses). Owned by
+  `tag:k8s-igait-operator`, so *only the Operator* can register a
+  device with this tag.
+
+### Tailnet ACL snippet
+
+Required in `https://login.tailscale.com/admin/acls`:
+
+```hujson
+{
+  "tagOwners": {
+    "tag:k8s-igait-operator": [],                    // self-owned
+    "tag:k8s-igait": ["tag:k8s-igait-operator"],     // operator-owned
+    // ...existing tags unchanged
+  },
+  "acls": [
+    // Let tailnet members reach workload devices:
+    { "action": "accept", "src": ["autogroup:member"], "dst": ["tag:k8s-igait:*"] },
+    // ...existing rules unchanged
+  ],
+}
+```
+
+### OAuth client scope footgun
+
+The OAuth client used by the Operator **must** have `tag:k8s-igait-operator`
+AND `tag:k8s-igait` in its allowed tags list (Tailscale admin →
+OAuth clients → edit → Tags). Without this, auth-key minting fails
+with an opaque 401 and the Operator logs "failed to create auth key"
+with no clue why. Scope at the OAuth client should be:
+
+- Devices: Core Read+Write
+- Auth Keys: Write
+- Tags: `tag:k8s-igait-operator`, `tag:k8s-igait`
+
+### Rotating Tailscale OAuth creds
+
+Same pattern as any other SSM param — edit the value under
+`/igait/prod/tailscale/*`, wait ≤5m, restart the Operator:
+
+```bash
+kubectl -n tailscale rollout restart deployment/operator
+```

--- a/docs/deployment/external-secrets.md
+++ b/docs/deployment/external-secrets.md
@@ -1,0 +1,158 @@
+# External Secrets Operator + AWS SSM Parameter Store
+
+> Replaces the manual Vaultwarden ↔ `igait-secrets` dual-update flow described
+> in `docs/environment/vaultwarden.md`. Prod secrets now live in AWS SSM
+> Parameter Store under `/igait/prod/*`; ESO materializes them into K8s Secrets.
+
+## Architecture
+
+```
+AWS SSM Parameter Store          Kubernetes cluster
+─────────────────────────        ───────────────────────────────────────────
+/igait/prod/env/*         ──┐    ┌── Secret/igait-secrets  (ns: igait)
+                            ├──▶ │
+/igait/prod/gcp-key/*     ──┘    └── Secret/gcp-key        (ns: igait)
+                                        ▲
+                                        │ ExternalSecret CRs + ClusterSecretStore
+                                        │ reconciled by external-secrets-operator
+                                        │ every 5m
+                             bootstrap: Secret/aws-ssm-creds  (ns: external-secrets)
+                                        │ single static IAM user, read-only on
+                                        │ arn:aws:ssm:us-east-2:*:parameter/igait/prod/*
+```
+
+## Bootstrap (one-time, per cluster)
+
+The `aws-ssm-creds` Secret is the one credential **not** managed by ESO — it's
+what ESO uses to talk to AWS. Create it manually:
+
+```bash
+# 1. In AWS IAM, create user `igait-eso-ssm-reader` with programmatic access
+#    and the policy in `Minimum IAM policy` below. Save the access key.
+
+# 2. Create the bootstrap Secret in-cluster:
+kubectl create namespace external-secrets || true
+kubectl -n external-secrets create secret generic aws-ssm-creds \
+  --from-literal=access-key-id=AKIA... \
+  --from-literal=secret-access-key=...
+```
+
+Rotate every 90 days (track in team calendar; automation pending).
+
+## Minimum IAM policy
+
+Attach to `igait-eso-ssm-reader`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ReadIgaitProdParameters",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParametersByPath",
+        "ssm:DescribeParameters"
+      ],
+      "Resource": "arn:aws:ssm:us-east-2:*:parameter/igait/prod/*"
+    },
+    {
+      "Sid": "DecryptSecureStrings",
+      "Effect": "Allow",
+      "Action": "kms:Decrypt",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "ssm.us-east-2.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+```
+
+The `kms:Decrypt` condition scopes decryption to keys invoked via SSM — even
+though the `Resource: "*"` looks loose, the condition makes it safe.
+
+## Cutover playbook (initial migration from manually-applied Secrets)
+
+Run **after** the PR is merged and ArgoCD has synced, and **after** all 14 SSM
+params are populated:
+
+```bash
+# 1. Verify ESO pods are Running.
+kubectl -n external-secrets get pods
+
+# 2. Verify ClusterSecretStore is Ready.
+kubectl get clustersecretstore aws-ssm \
+  -o jsonpath='{.status.conditions[0].type}={.status.conditions[0].status}'
+# Expect: Ready=True
+
+# 3. Check ExternalSecret status — will say SecretSyncedError because the
+#    existing manually-applied Secret blocks `creationPolicy: Owner` takeover.
+kubectl -n igait get externalsecret
+
+# 4. Back up current Secrets (paranoia — 10 seconds of insurance):
+kubectl -n igait get secret igait-secrets -o yaml > /tmp/igait-secrets.bak.yaml
+kubectl -n igait get secret gcp-key       -o yaml > /tmp/gcp-key.bak.yaml
+
+# 5. Delete the manually-applied Secrets. ESO recreates from SSM within seconds.
+kubectl -n igait delete secret igait-secrets gcp-key
+
+# 6. Confirm ESO created fresh Secrets (look for owner reference to ExternalSecret):
+kubectl -n igait get secret igait-secrets -o yaml | grep -A2 ownerReferences
+
+# 7. Restart backend to pick up the new Secret values (envFrom would hot-reload,
+#    but we use individual `secretKeyRef` which only re-read on pod start):
+kubectl -n igait rollout restart deployment/backend
+kubectl -n igait rollout status deployment/backend
+```
+
+Rollback (if step 5 goes sideways):
+
+```bash
+kubectl -n igait apply -f /tmp/igait-secrets.bak.yaml
+kubectl -n igait apply -f /tmp/gcp-key.bak.yaml
+```
+
+## Rotation verification
+
+Exercise the full loop end-to-end — should be done once after initial cutover:
+
+```bash
+# 1. In AWS console, edit /igait/prod/env/OPENAI_ASSISTANT_ID to a dummy value.
+# 2. Wait up to 5m (refreshInterval).
+# 3. Confirm the in-cluster Secret reflects the new value:
+kubectl -n igait get secret igait-secrets \
+  -o jsonpath='{.data.OPENAI_ASSISTANT_ID}' | base64 -d ; echo
+# 4. Revert the SSM param to the real value, repeat step 3 to confirm.
+```
+
+## Param reference
+
+14 parameters, all `SecureString` + Intelligent-Tiering + AWS-managed KMS:
+
+| SSM path | Target K8s Secret key |
+|---|---|
+| `/igait/prod/env/GOOGLE_APPLICATION_CREDENTIALS` | `igait-secrets.GOOGLE_APPLICATION_CREDENTIALS` |
+| `/igait/prod/env/FIREBASE_PROJECT_ID` | `igait-secrets.FIREBASE_PROJECT_ID` |
+| `/igait/prod/env/FIREBASE_ACCESS_KEY` | `igait-secrets.FIREBASE_ACCESS_KEY` |
+| `/igait/prod/env/FIREBASE_RTDB_URL` | `igait-secrets.FIREBASE_RTDB_URL` |
+| `/igait/prod/env/IGAIT_S3_BUCKET` | `igait-secrets.IGAIT_S3_BUCKET` |
+| `/igait/prod/env/SES_FROM_ADDRESS` | `igait-secrets.SES_FROM_ADDRESS` |
+| `/igait/prod/env/SES_FROM_IDENTITY_ARN` | `igait-secrets.SES_FROM_IDENTITY_ARN` |
+| `/igait/prod/env/AWS_REGION` | `igait-secrets.AWS_REGION` |
+| `/igait/prod/env/AWS_ACCESS_KEY_ID` | `igait-secrets.AWS_ACCESS_KEY_ID` |
+| `/igait/prod/env/AWS_SECRET_ACCESS_KEY` | `igait-secrets.AWS_SECRET_ACCESS_KEY` |
+| `/igait/prod/env/OPENAI_API_KEY` | `igait-secrets.OPENAI_API_KEY` |
+| `/igait/prod/env/OPENAI_ASSISTANT_ID` | `igait-secrets.OPENAI_ASSISTANT_ID` |
+| `/igait/prod/env/OPENAI_VECTOR_STORE_ID` | `igait-secrets.OPENAI_VECTOR_STORE_ID` |
+| `/igait/prod/gcp-key/key.json` | `gcp-key.gcp-key.json` |
+
+To add a new secret: put it in SSM under `/igait/prod/env/` and it'll appear
+in `igait-secrets` on the next refresh — the `dataFrom: find:` selector in
+`infra/k8s/backend/external-secrets.yaml` auto-discovers everything under
+that path. Then add a `secretKeyRef` entry in the backend deployment to
+surface it as an env var.

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
                     (firebase-tools.override {
                         buildNpmPackage = buildNpmPackage.override { nodejs = nodejs_22; };
                     })
+                    awscli
 
                     # Build dependencies
                     pkg-config

--- a/infra/k8s/argocd/apps/external-secrets-config.yaml
+++ b/infra/k8s/argocd/apps/external-secrets-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets-config
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igait-niu/igait.git
+    targetRevision: main
+    path: infra/k8s/external-secrets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/infra/k8s/argocd/apps/external-secrets.yaml
+++ b/infra/k8s/argocd/apps/external-secrets.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.external-secrets.io
+    chart: external-secrets
+    targetRevision: 0.10.7
+    helm:
+      values: |
+        installCRDs: true
+        webhook:
+          port: 9443
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/k8s/argocd/apps/tailscale-operator-config.yaml
+++ b/infra/k8s/argocd/apps/tailscale-operator-config.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tailscale-operator-config
+  namespace: argocd
+  annotations:
+    # Syncs before the tailscale-operator chart itself, so the
+    # namespace + operator-oauth Secret exist before the Operator
+    # Deployment starts (which references operator-oauth via
+    # secretKeyRef and would crashloop otherwise).
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/igait-niu/igait.git
+    targetRevision: main
+    path: infra/k8s/tailscale-operator
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tailscale
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/infra/k8s/argocd/apps/tailscale-operator.yaml
+++ b/infra/k8s/argocd/apps/tailscale-operator.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tailscale-operator
+  namespace: argocd
+  annotations:
+    # Syncs after tailscale-operator-config so the Operator Deployment
+    # starts with operator-oauth Secret already materialized by ESO.
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+  source:
+    repoURL: https://pkgs.tailscale.com/helmcharts
+    chart: tailscale-operator
+    targetRevision: 1.76.1
+    helm:
+      values: |
+        # Leave OAuth values empty so the chart skips creating
+        # operator-oauth itself — we create it via ExternalSecret in
+        # tailscale-operator-config. The chart's Deployment still
+        # references `operator-oauth` via secretKeyRef, picking up our
+        # ESO-managed Secret.
+        oauth:
+          clientId: ""
+          clientSecret: ""
+        operatorConfig:
+          defaultTags:
+            - tag:k8s-igait-operator
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tailscale
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/infra/k8s/backend/external-secrets.yaml
+++ b/infra/k8s/backend/external-secrets.yaml
@@ -1,0 +1,38 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: igait-secrets
+  namespace: igait
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: igait-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - find:
+        path: /igait/prod/env/
+      rewrite:
+        - regexp:
+            source: "^/igait/prod/env/(.+)$"
+            target: "$1"
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gcp-key
+  namespace: igait
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: gcp-key
+    creationPolicy: Owner
+  data:
+    - secretKey: gcp-key.json
+      remoteRef:
+        key: /igait/prod/gcp-key/key.json

--- a/infra/k8s/external-secrets/cluster-secret-store.yaml
+++ b/infra/k8s/external-secrets/cluster-secret-store.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: aws-ssm
+spec:
+  provider:
+    aws:
+      service: ParameterStore
+      region: us-east-2
+      auth:
+        secretRef:
+          accessKeyIDSecretRef:
+            name: aws-ssm-creds
+            key: access-key-id
+            namespace: external-secrets
+          secretAccessKeySecretRef:
+            name: aws-ssm-creds
+            key: secret-access-key
+            namespace: external-secrets

--- a/infra/k8s/external-secrets/kustomization.yaml
+++ b/infra/k8s/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cluster-secret-store.yaml

--- a/infra/k8s/kustomization.yaml
+++ b/infra/k8s/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - backend/rbac.yaml
   - backend/deployment.yaml
   - backend/service.yaml
+  - backend/external-secrets.yaml

--- a/infra/k8s/tailscale-operator/external-secret.yaml
+++ b/infra/k8s/tailscale-operator/external-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: operator-oauth
+  namespace: tailscale
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: operator-oauth
+    creationPolicy: Owner
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: /igait/prod/tailscale/client_id
+    - secretKey: client_secret
+      remoteRef:
+        key: /igait/prod/tailscale/client_secret

--- a/infra/k8s/tailscale-operator/kustomization.yaml
+++ b/infra/k8s/tailscale-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - external-secret.yaml

--- a/infra/k8s/tailscale-operator/namespace.yaml
+++ b/infra/k8s/tailscale-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale


### PR DESCRIPTION
## Summary

Closes #105.

- Replace manual Vaultwarden ↔ `igait-secrets` dual-update with **ESO + AWS SSM Parameter Store**. ESO's AWS provider is first-class (eliminates the community-plugin risk flagged in the original issue).
- Install **Tailscale Operator** (v1.76.1) with ESO-managed OAuth creds — no chart-managed Secrets.
- Add `awscli` to the Nix dev shell for SSM ops / rotation verification.

## What's in this PR

| Path | Purpose |
|---|---|
| `flake.nix` | +`awscli` in dev shell |
| `infra/k8s/argocd/apps/external-secrets.yaml` | ArgoCD App → ESO Helm chart v0.10.7 |
| `infra/k8s/argocd/apps/external-secrets-config.yaml` | ArgoCD App → our `ClusterSecretStore` |
| `infra/k8s/external-secrets/cluster-secret-store.yaml` | `ClusterSecretStore/aws-ssm` (region `us-east-2`, authed via `aws-ssm-creds`) |
| `infra/k8s/backend/external-secrets.yaml` | 2× `ExternalSecret` — `igait-secrets` (via `dataFrom: find:`) + `gcp-key` (explicit) |
| `infra/k8s/argocd/apps/tailscale-operator-config.yaml` | ArgoCD App → our `tailscale` namespace + `operator-oauth` ExternalSecret (sync-wave `-1`) |
| `infra/k8s/argocd/apps/tailscale-operator.yaml` | ArgoCD App → Tailscale Helm chart v1.76.1 (sync-wave `0`) |
| `infra/k8s/tailscale-operator/*` | namespace + `ExternalSecret` manifest for the Operator's OAuth creds |
| `docs/deployment/external-secrets.md` | Architecture, IAM policy, cutover playbook, rotation, Tailscale section |

## Pre-merge checklist (ops work already completed)

- [x] 14 SSM params populated under `/igait/prod/env/*` + `/igait/prod/gcp-key/*`
- [x] 2 Tailscale OAuth params under `/igait/prod/tailscale/*`
- [x] IAM user `igait-eso-ssm-reader` created with scoped policy (rotated after initial key leak to README working tree — **never committed**, verified via `git log --all -S`)
- [x] `aws-ssm-creds` bootstrap Secret in `external-secrets` namespace
- [x] Tailnet tags `tag:k8s-igait-operator` + `tag:k8s-igait` created with correct ownership (self → operator, operator → workload)

## Pre-merge checklist (remaining)

- [ ] Tailnet ACL HuJSON updated with `tagOwners` entries + accept rule (snippet in `docs/deployment/external-secrets.md`)
- [ ] Tailscale OAuth client's allowed-tags list includes **both** `tag:k8s-igait-operator` AND `tag:k8s-igait` (common footgun — opaque 401 without this)

## Post-merge cutover (manual)

After ArgoCD syncs, the backend `ExternalSecret`s enter `SecretSyncedError` because the existing manually-applied `igait-secrets` / `gcp-key` block `creationPolicy: Owner` takeover. Run the cutover playbook in `docs/deployment/external-secrets.md`:

1. Verify `ClusterSecretStore/aws-ssm` reports `Ready=True`
2. Run the scratch smoke-test (`eso-test` namespace pulls `AWS_REGION` — zero-risk end-to-end proof)
3. Back up existing Secrets locally
4. `kubectl -n igait delete secret igait-secrets gcp-key` — ESO recreates within seconds
5. `kubectl -n igait rollout restart deployment/backend`

Tailscale Operator pod should come up Healthy without manual intervention — `operator-oauth` materializes at sync-wave `-1`, Operator starts at wave `0`.

## Test plan

- [ ] ArgoCD shows `external-secrets`, `external-secrets-config`, `tailscale-operator-config`, `tailscale-operator` all Synced + Healthy
- [ ] `kubectl get clustersecretstore aws-ssm` → `Ready=True`
- [ ] Scratch smoke test materializes `AWS_REGION` → `us-east-2`
- [ ] Post-cutover: `kubectl -n igait get externalsecret` → all `SecretSynced=True`
- [ ] Backend pod starts cleanly, handles a real request (S3 upload + SES email + Firebase write)
- [ ] `kubectl -n tailscale logs deploy/operator` → successful OAuth token fetch, no 401s
- [ ] SSM param rotation round-trip: edit one param, wait ≤5m, confirm in-cluster Secret reflects new value

## Notes

- **Vaultwarden kept in-cluster.** The `https://vault.igaitapp.com` instance continues to serve non-prod-secret items (team personal creds, historical archival). Retirement is a separate ticket, post-bake.
- **Sync waves.** `tailscale-operator-config` annotated with `argocd.argoproj.io/sync-wave: "-1"`, `tailscale-operator` with `"0"` — guarantees `operator-oauth` Secret exists before the Operator Deployment starts.