### PR TITLE
#105 fixup: Tailscale tag config + tagOwners docs

### DIFF
--- a/docs/deployment/external-secrets.md
+++ b/docs/deployment/external-secrets.md
@@ -195,8 +195,11 @@ Required in `https://login.tailscale.com/admin/acls`:
 ```hujson
 {
   "tagOwners": {
-    "tag:k8s-igait-operator": [],                    // self-owned
-    "tag:k8s-igait": ["tag:k8s-igait-operator"],     // operator-owned
+    // admins mint the Operator's own auth keys -- empty list means
+    // nobody can mint it (Tailscale returns 400 "not permitted"):
+    "tag:k8s-igait-operator": ["autogroup:admin"],
+    // only the Operator spawns workload devices:
+    "tag:k8s-igait": ["tag:k8s-igait-operator"],
     // ...existing tags unchanged
   },
   "acls": [

--- a/infra/k8s/argocd/apps/tailscale-operator.yaml
+++ b/infra/k8s/argocd/apps/tailscale-operator.yaml
@@ -23,9 +23,18 @@ spec:
         oauth:
           clientId: ""
           clientSecret: ""
+        # Tag applied to the Operator pod's own tailnet device. Must be
+        # in the OAuth client's allowed tags list AND have an owner in
+        # the tailnet ACL's tagOwners (typically `autogroup:admin`).
         operatorConfig:
           defaultTags:
             - tag:k8s-igait-operator
+        # Tag applied to proxy devices the Operator spawns (exposed
+        # Services etc.). tagOwners must list `tag:k8s-igait-operator`
+        # as an owner so only the Operator can mint these.
+        proxyConfig:
+          defaultTags:
+            - tag:k8s-igait
   destination:
     server: https://kubernetes.default.svc
     namespace: tailscale


### PR DESCRIPTION
## Summary

Post-merge fixup for #136. Two bugs caught during the first sync:

1. **Chart values** — my earlier `operatorConfig.defaultTags: [tag:k8s-igait-operator]` was setting the self-tag at a key that mapped to `PROXY_TAGS` (the chart default was bleeding through). Corrected to both:
   - `operatorConfig.defaultTags: [tag:k8s-igait-operator]` — Operator pod's own tailnet device
   - `proxyConfig.defaultTags: [tag:k8s-igait]` — devices spawned by the Operator for exposed Services

2. **Docs tagOwners snippet** — had `tag:k8s-igait-operator: []` (empty list). Empty list means nobody can mint auth keys with that tag, so Tailscale returns `400 "requested tags [tag:k8s-igait-operator] are invalid or not permitted"` and the Operator crashloops on startup. Corrected to `["autogroup:admin"]`.

## Observed symptom

```
{"level":"fatal","logger":"startup","msg":"creating operator authkey: Status: 400,
 Message: \"requested tags [tag:k8s-igait-operator] are invalid or not permitted\""}
```

## Required manual step before this lands cleanly

Update the tailnet ACL in `https://login.tailscale.com/admin/acls`:

```hujson
"tagOwners": {
  "tag:k8s-igait-operator": ["autogroup:admin"],
  "tag:k8s-igait":          ["tag:k8s-igait-operator"],
  // ...existing tags unchanged
},
```

Without the ACL update, Tailscale still rejects the auth-key mint regardless of Helm values. ACL update + merge together unblocks the Operator.

## Test plan

- [x] Merge ACL update in Tailscale admin
- [x] Merge this PR → ArgoCD syncs updated Helm values
- [ ] `kubectl -n tailscale delete pod -l ...` → new pod picks up new values
- [ ] `kubectl -n tailscale logs deploy/operator` → no 400, Operator registers successfully
- [ ] `tailscale status` from another tailnet device shows the Operator as `tag:k8s-igait-operator`

Refs #105.