### PR TITLE
#105 fixup: ExternalSecret find syntax for AWS SSM provider

### DIFF
--- a/infra/k8s/backend/external-secrets.yaml
+++ b/infra/k8s/backend/external-secrets.yaml
@@ -13,7 +13,8 @@ spec:
     creationPolicy: Owner
   dataFrom:
     - find:
-        path: /igait/prod/env/
+        name:
+          regexp: "^/igait/prod/env/.+"
       rewrite:
         - regexp:
             source: "^/igait/prod/env/(.+)$"


### PR DESCRIPTION
## Summary

Third post-merge fixup for #105. The `igait-secrets` ExternalSecret was stuck in `SecretSyncedError` with ESO logging `unexpected find operator`.

**Root cause:** I used `dataFrom.find.path:` as a top-level matcher, which the AWS SSM provider's `find` schema in ESO v1beta1 doesn't accept. The documented matchers are `name.regexp`, `name.gitea`, or `tags`. Switched to `name.regexp` with a path-prefix regex.

## Diff

```yaml
# before:
dataFrom:
  - find:
      path: /igait/prod/env/
    rewrite: [...]

# after:
dataFrom:
  - find:
      name:
        regexp: "^/igait/prod/env/.+"
    rewrite: [...]
```

Net behavior is **identical** — still auto-discovers everything under `/igait/prod/env/` on every reconcile, so adding a new backend secret remains a one-step SSM operation.

## Observed symptom

```
kubectl -n igait describe externalsecret igait-secrets
  Status: False  Reason: SecretSyncedError
  Message: could not get secret data from provider
Events:
  Warning UpdateFailed  6x over 7m10s  external-secrets  unexpected find operator
```

## Test plan

- [ ] Merge
- [ ] ArgoCD syncs within seconds
- [ ] `kubectl -n igait get externalsecret igait-secrets -o jsonpath='{.status.conditions[*].type}={.status.conditions[*].status}'` → `Ready=True`
- [ ] `kubectl -n igait get secret igait-secrets` shows `DATA: 13` (but still owned by the manual creator, not ESO — cutover step still required)
- [ ] Run cutover playbook per `docs/deployment/external-secrets.md`

Refs #105.