### PR TITLE
#105 fixup: proxyConfig.defaultTags must be a string

### DIFF
--- a/infra/k8s/argocd/apps/tailscale-operator.yaml
+++ b/infra/k8s/argocd/apps/tailscale-operator.yaml
@@ -32,9 +32,12 @@ spec:
         # Tag applied to proxy devices the Operator spawns (exposed
         # Services etc.). tagOwners must list `tag:k8s-igait-operator`
         # as an owner so only the Operator can mint these.
+        # Chart quirk: proxyConfig.defaultTags is templated *verbatim*
+        # into env[].value, which must be a string. A YAML list here
+        # produces `value: [tag:k8s-igait]` → API rejects with the
+        # opaque "unrecognized type: string". Pass as a string.
         proxyConfig:
-          defaultTags:
-            - tag:k8s-igait
+          defaultTags: "tag:k8s-igait"
   destination:
     server: https://kubernetes.default.svc
     namespace: tailscale


### PR DESCRIPTION
## Summary

Clears the `SyncError` we've been seeing on the `tailscale-operator` ArgoCD Application — cryptically reported as `error when patching "/dev/shm/<N>": "" is invalid: patch: Invalid value: "": unrecognized type: string`.

## Root cause

The Tailscale Operator chart inconsistently handles two sibling keys:

| Key | Renders as |
|---|---|
| `operatorConfig.defaultTags: [...]` | Joined into a string → `OPERATOR_INITIAL_TAGS: "..."` ✅ |
| `proxyConfig.defaultTags: [...]` | Passed **verbatim** into `env[].value` → `value: [tag:...]` ❌ |

K8s API rejects the list-valued `env[].value` (must be a string), producing the opaque SMP error.

## Diff

```yaml
  proxyConfig:
-   defaultTags:
-     - tag:k8s-igait
+   defaultTags: "tag:k8s-igait"
```

## Why the Operator still ran

Chart default `PROXY_TAGS: tag:k8s` stuck in the live Deployment because our override was structurally invalid and ArgoCD's patch kept failing. Operator pod was (unknowingly) tagging spawned proxies with `tag:k8s` rather than `tag:k8s-igait`. This PR corrects that too — after merge, newly-spawned proxy devices will correctly bear `tag:k8s-igait`.

## Test plan

- [ ] Merge
- [ ] ArgoCD Application `tailscale-operator` → `Synced` (no more SyncError)
- [ ] `kubectl -n tailscale get deploy operator -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="PROXY_TAGS")].value}'` → `tag:k8s-igait`
- [ ] Existing Operator pod continues running; no restart needed for this change (env propagates to the next proxy device the Operator spawns)

Refs #105.