### PR TITLE
#106 (slice 1/3): preview-comment GH Actions workflow

### DIFF
--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -1,0 +1,54 @@
+name: preview-comment
+
+# Uses `pull_request_target` (not `pull_request`) so fork PRs also get the
+# comment — `pull_request` from a fork drops write perms even when declared.
+# Safe here because we never check out PR code; we only call the GitHub API
+# with a repo-scoped token and the PR number from the event payload.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `https://igait-pr-${context.issue.number}.igait-niu.org.github.ts.net`;
+            const marker = '<!-- igait-preview-url -->';
+            const body = [
+              marker,
+              `**Preview:** ${url}`,
+              '',
+              '_Accessible only to members of the `igait-niu.org.github` tailnet._',
+              '_Previews take ~2 min to spin up after the label is applied._',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              if (existing.body === body) return;
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

Slice 1 of 3 for #106 (per-PR preview environments). Self-contained — just adds a GitHub Actions workflow; no infra changes yet.

- New workflow `.github/workflows/preview-comment.yml` posts and idempotently updates a single comment with the MagicDNS preview URL (`https://igait-pr-<N>.igait-niu.org.github.ts.net`) on any PR labeled `preview`.
- Idempotency via an HTML marker (`<!-- igait-preview-url -->`) — the workflow updates the existing comment in-place instead of spamming.
- Uses `pull_request_target` so fork PRs get the comment too. Safe here: no PR code is checked out, only the API is called with the PR number from the event payload.

## Test plan

- [ ] After merge, open a throwaway PR against `main` and apply the `preview` label → verify one (and only one) bot comment lands with the right URL.
- [ ] Remove + re-add the label → verify the comment stays at one (update, not duplicate).
- [ ] Open a PR without the `preview` label → verify no comment is posted.
- [ ] Visible URL won't actually resolve until slice 2 + 3 land; that's expected.

## Follow-ups (tracked in #106)

- Slice 2: preview Kustomize overlay + emulator manifests (`infra/k8s/overlays/preview/`)
- Slice 3: ArgoCD ApplicationSet + \`github-pr-token\` ESO wiring (`infra/k8s/argocd/apps/`)

Closes #106 on slice 3 merge; this slice alone doesn't close it.