### PR TITLE
#106 (slice 1b): drop `preview` label gate — previews always-on

### DIFF
--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -6,12 +6,11 @@ name: preview-comment
 # with a repo-scoped token and the PR number from the event payload.
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize]
 
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'preview')
     permissions:
       pull-requests: write
     steps:
@@ -25,7 +24,7 @@ jobs:
               `**Preview:** ${url}`,
               '',
               '_Accessible only to members of the `igait-niu.org.github` tailnet._',
-              '_Previews take ~2 min to spin up after the label is applied._',
+              '_Previews take ~2 min to spin up; they tear down when the PR closes._',
             ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
## Summary

Follow-up to #141. Drops the \`contains(...labels...)\` gate and the \`labeled\` event from the preview-comment workflow so every PR automatically gets a preview-URL comment. Matches the design decision to auto-spin-up previews on PR open and tear down on close (ArgoCD prune handles the teardown in slice 3).

- Removed \`if: contains(github.event.pull_request.labels.*.name, 'preview')\`
- Removed \`labeled\` from the event types list (no longer meaningful)
- Updated comment copy to reference PR-close teardown instead of the label

## Test plan

- [ ] Merge + open a throwaway PR with no labels → one bot comment lands.
- [ ] Confirm still idempotent on \`synchronize\` (push to PR).

## Follow-up

The \`preview\` GitHub label is now unused for gating. Leaving it in place for now; can be deleted in a cleanup pass.