### PR TITLE
#106 (slice 2a): publish firebase-emulator image to GHCR

### DIFF
--- a/.github/workflows/build-firebase-emulator.yml
+++ b/.github/workflows/build-firebase-emulator.yml
@@ -1,0 +1,62 @@
+name: Build Firebase Emulator
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'infra/docker/firebase-emulator/**'
+      - 'infra/firebase/**'
+      - '.github/workflows/build-firebase-emulator.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/firebase-emulator
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./infra/docker/firebase-emulator
+          file: ./infra/docker/firebase-emulator/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # NOTE: no k8s manifest sed-patch step yet. The firebase-emulator image
+      # is only referenced from the preview Kustomize overlay, which lands in
+      # slice 2b of #106. Once that's merged, add a step here that updates
+      # infra/k8s/overlays/preview/emulators/firebase/deployment.yaml with the
+      # new sha — same pattern as build-backend.yml.


### PR DESCRIPTION
## Summary

Slice 2a of #106. Prerequisite to the preview Kustomize overlay (slice 2b) — the preview namespace needs a pullable firebase-emulator image, and compose's \`build: ./docker/firebase-emulator\` doesn't cut it for in-cluster use.

- New workflow \`build-firebase-emulator.yml\` builds \`infra/docker/firebase-emulator/Dockerfile\` for \`linux/arm64\` and pushes to \`ghcr.io/igait-niu/igait/firebase-emulator:{sha-<short>,latest}\`.
- Triggers on changes to the emulator Dockerfile or the Firebase RTDB rules under \`infra/firebase/\`.
- No k8s manifest sed-patch step yet — nothing references the image in-cluster until slice 2b lands. A note in the workflow file tracks the follow-up.

## Test plan

- [ ] Merge → workflow fires via \`workflow_dispatch\` → image appears under the repo's Packages.
- [ ] \`docker pull ghcr.io/igait-niu/igait/firebase-emulator:latest\` succeeds on an arm64 host.
- [ ] Slice 2b references the \`sha-<short>\` tag and the emulator Deployment starts in a preview namespace.

## Follow-up in slice 2b

Add the sed-patch step at the end of the workflow, targeting \`infra/k8s/overlays/preview/emulators/firebase/deployment.yaml\` (path subject to overlay final shape).