### PR TITLE
#106 (slice 2b): preview Kustomize overlay + orchestrator namespace dynamic

### DIFF
--- a/apps/backend/src/helper/orchestrator.rs
+++ b/apps/backend/src/helper/orchestrator.rs
@@ -29,13 +29,49 @@ use lib::microservice::{
     JOB_RESULT_TAKE_TIMEOUT_MS,
 };
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tracing::{error, info, instrument, warn};
 
 /// The K8s namespace where pipeline Jobs are created.
-const NAMESPACE: &str = "igait";
+///
+/// Resolved once at first use from (in order):
+///   1. `POD_NAMESPACE` env var (set via downward API, if present)
+///   2. the namespace file auto-mounted into every pod by the kubelet
+///   3. the literal `"igait"` fallback, preserving historical behavior
+///      outside a cluster (e.g. local `cargo run` against a remote API).
+///
+/// Making this dynamic is what lets one backend image serve production
+/// (`igait` ns) and per-PR preview envs (`igait-pr-<N>` ns) without a
+/// rebuild — Jobs land in whichever namespace the backend pod itself
+/// lives in.
+fn pipeline_namespace() -> &'static str {
+    static NS: OnceLock<String> = OnceLock::new();
+    NS.get_or_init(|| {
+        let env = std::env::var("POD_NAMESPACE").ok();
+        let file =
+            std::fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/namespace").ok();
+        resolve_namespace(env.as_deref(), file.as_deref())
+    })
+    .as_str()
+}
+
+/// Pure namespace-resolution logic, extracted so it's testable without
+/// touching real env vars or the filesystem.
+fn resolve_namespace(env_var: Option<&str>, sa_file: Option<&str>) -> String {
+    env_var
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            sa_file
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "igait".to_string())
+}
 
 /// The K8s secret containing pipeline environment variables.
 const SECRET_NAME: &str = "igait-secrets";
@@ -224,7 +260,7 @@ impl Orchestrator {
             job_epoch,
         );
 
-        let jobs_api: Api<Job> = Api::namespaced(self.kube_client.clone(), NAMESPACE);
+        let jobs_api: Api<Job> = Api::namespaced(self.kube_client.clone(), pipeline_namespace());
         jobs_api
             .create(&PostParams::default(), &k8s_job)
             .await
@@ -265,7 +301,7 @@ impl Orchestrator {
             job_epoch,
         );
 
-        let jobs_api: Api<Job> = Api::namespaced(self.kube_client.clone(), NAMESPACE);
+        let jobs_api: Api<Job> = Api::namespaced(self.kube_client.clone(), pipeline_namespace());
         jobs_api
             .create(&PostParams::default(), &k8s_job)
             .await
@@ -318,7 +354,7 @@ impl Orchestrator {
         Job {
             metadata: ObjectMeta {
                 name: Some(job_name.to_string()),
-                namespace: Some(NAMESPACE.to_string()),
+                namespace: Some(pipeline_namespace().to_string()),
                 labels: Some(std::collections::BTreeMap::from([
                     ("app".to_string(), "igait-pipeline".to_string()),
                     ("managed-by".to_string(), "backend".to_string()),
@@ -753,7 +789,7 @@ impl Orchestrator {
     /// proactive "please stop now" that avoids the wasted compute.
     #[instrument(skip(self), fields(job_id = %job_id))]
     pub async fn cancel_in_flight_jobs(&self, job_id: &str) -> Result<usize> {
-        let jobs_api: Api<Job> = Api::namespaced(self.kube_client.clone(), NAMESPACE);
+        let jobs_api: Api<Job> = Api::namespaced(self.kube_client.clone(), pipeline_namespace());
         let lp = ListParams::default().labels("app=igait-pipeline,managed-by=backend");
 
         let job_list = jobs_api
@@ -804,7 +840,7 @@ impl Orchestrator {
     /// Checks for stale K8s Jobs that have failed/timed out without writing a result.
     #[instrument(skip(self))]
     async fn check_stale_jobs(&self) -> Result<()> {
-        let jobs_api: Api<Job> = Api::namespaced(self.kube_client.clone(), NAMESPACE);
+        let jobs_api: Api<Job> = Api::namespaced(self.kube_client.clone(), pipeline_namespace());
         let lp = ListParams::default().labels("app=igait-pipeline,managed-by=backend");
 
         let job_list = jobs_api
@@ -1011,5 +1047,44 @@ pub async fn completion_monitor_loop(orchestrator: Arc<Orchestrator>) {
         }
 
         tokio::time::sleep(Duration::from_secs(COMPLETION_POLL_INTERVAL_SECS)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_namespace;
+
+    #[test]
+    fn env_var_wins_when_present() {
+        assert_eq!(
+            resolve_namespace(Some("igait-pr-42"), Some("should-be-ignored")),
+            "igait-pr-42",
+        );
+    }
+
+    #[test]
+    fn falls_back_to_service_account_file() {
+        assert_eq!(resolve_namespace(None, Some("igait-pr-7\n")), "igait-pr-7",);
+    }
+
+    #[test]
+    fn empty_env_var_is_skipped() {
+        // Kubelets sometimes inject empty strings for unset downward-API
+        // fields; we treat those as absent rather than as the namespace
+        // literally being "".
+        assert_eq!(
+            resolve_namespace(Some(""), Some("igait-pr-9")),
+            "igait-pr-9"
+        );
+        assert_eq!(
+            resolve_namespace(Some("   "), Some("igait-pr-9")),
+            "igait-pr-9"
+        );
+    }
+
+    #[test]
+    fn final_fallback_is_igait() {
+        assert_eq!(resolve_namespace(None, None), "igait");
+        assert_eq!(resolve_namespace(Some(""), Some("")), "igait");
     }
 }

--- a/infra/overlays/preview/emulators/firebase/deployment.yaml
+++ b/infra/overlays/preview/emulators/firebase/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: firebase-emulator
+  labels:
+    app: firebase-emulator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: firebase-emulator
+  # Emulator state is ephemeral — on restart, firebase-bootstrap Job
+  # re-seeds the admin account. No rolling update dance needed.
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: firebase-emulator
+    spec:
+      containers:
+        - name: firebase-emulator
+          # Pushed by .github/workflows/build-firebase-emulator.yml;
+          # image-tag is patched in per-PR by the ApplicationSet (slice 3)
+          # via kustomize.images. :latest is only a render-time default.
+          image: ghcr.io/igait-niu/igait/firebase-emulator:latest
+          ports:
+            - name: rtdb
+              containerPort: 9000
+            - name: auth
+              containerPort: 9099
+            - name: ui
+              containerPort: 4000
+          # Match compose's 30s start_period — the JVM takes a beat to
+          # bind 9000 and 9099, and we want Jobs that hit the emulator
+          # to not race its boot.
+          readinessProbe:
+            httpGet:
+              path: /.json?ns=igait-local
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi

--- a/infra/overlays/preview/emulators/firebase/service.yaml
+++ b/infra/overlays/preview/emulators/firebase/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: firebase-emulator
+  labels:
+    app: firebase-emulator
+spec:
+  type: ClusterIP
+  selector:
+    app: firebase-emulator
+  ports:
+    - name: rtdb
+      port: 9000
+      targetPort: 9000
+    - name: auth
+      port: 9099
+      targetPort: 9099
+    - name: ui
+      port: 4000
+      targetPort: 4000

--- a/infra/overlays/preview/emulators/minio/bootstrap-job.yaml
+++ b/infra/overlays/preview/emulators/minio/bootstrap-job.yaml
@@ -1,0 +1,42 @@
+# One-shot Job to create the `igait-storage` bucket on a fresh emulator.
+# Mirrors the `minio-bootstrap` compose service. Idempotent — `mc mb
+# --ignore-existing` is a no-op on re-run. Kustomize gives this Job a new
+# generated name on each apply so ArgoCD doesn't fight K8s over immutable
+# Job fields; for manual re-runs, delete the Job and let sync recreate.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-bootstrap
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: minio/mc:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              # Wait for minio to be reachable (readiness probe races sync timing).
+              for i in $(seq 1 60); do
+                if mc alias set local http://minio:9000 minioadmin minioadmin 2>/dev/null; then
+                  break
+                fi
+                sleep 1
+              done
+              mc mb --ignore-existing local/igait-storage
+              echo "MinIO bucket ready"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/infra/overlays/preview/emulators/minio/deployment.yaml
+++ b/infra/overlays/preview/emulators/minio/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args: ["server", "/data", "--console-address", ":9001"]
+          env:
+            - name: MINIO_ROOT_USER
+              value: minioadmin
+            - name: MINIO_ROOT_PASSWORD
+              value: minioadmin
+          ports:
+            - name: s3
+              containerPort: 9000
+            - name: console
+              containerPort: 9001
+          readinessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              cpu: 200m
+              memory: 512Mi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        # Previews are ephemeral — an emptyDir is fine, and keeps PVC
+        # cleanup from blocking namespace deletion on PR close.
+        - name: data
+          emptyDir: {}

--- a/infra/overlays/preview/emulators/minio/service.yaml
+++ b/infra/overlays/preview/emulators/minio/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  type: ClusterIP
+  selector:
+    app: minio
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001

--- a/infra/overlays/preview/emulators/ses-mock/deployment.yaml
+++ b/infra/overlays/preview/emulators/ses-mock/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ses-mock
+  labels:
+    app: ses-mock
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ses-mock
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: ses-mock
+    spec:
+      containers:
+        - name: ses-mock
+          image: ghcr.io/domdomegg/aws-ses-v2-local:latest
+          env:
+            - name: AUTH_MODE
+              value: open
+          ports:
+            - name: http
+              containerPort: 8005
+          # aws-ses-v2-local has no /health route and ships without
+          # curl/wget. Gate readiness on a TCP connect instead.
+          readinessProbe:
+            tcpSocket:
+              port: 8005
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/infra/overlays/preview/emulators/ses-mock/service.yaml
+++ b/infra/overlays/preview/emulators/ses-mock/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ses-mock
+  labels:
+    app: ses-mock
+spec:
+  type: ClusterIP
+  selector:
+    app: ses-mock
+  ports:
+    - name: http
+      port: 8005
+      targetPort: 8005

--- a/infra/overlays/preview/kustomization.yaml
+++ b/infra/overlays/preview/kustomization.yaml
@@ -1,0 +1,76 @@
+# Preview overlay — per-PR environment that runs the full iGait stack
+# against in-namespace emulators (Firebase, MinIO, ses-mock) instead of
+# real AWS + prod Firebase. The ArgoCD ApplicationSet (slice 3 of #106)
+# sets `namespace:` per-PR at render time via `kustomize.namespace`, so
+# the literal below is only a default for manual testing; in production
+# every preview namespace is named `igait-pr-<N>`.
+#
+# What this overlay does relative to the base (infra/k8s):
+#   1. Replaces both ExternalSecret resources (igait-secrets, gcp-key)
+#      with plain Secrets holding emulator-pointing literals. Emulator
+#      credentials are not secrets — baking them in keeps previews
+#      independent of ESO / SSM and avoids polluting prod SSM with
+#      preview-only values.
+#   2. Adds the three emulator Deployments + Services.
+#   3. Patches the backend Deployment to inject POD_NAMESPACE via the
+#      downward API, so the orchestrator's Job-creation namespace
+#      resolves to the preview ns instead of the `"igait"` fallback.
+#   4. Points backend at the in-namespace emulator services via a
+#      replacement of the Secret-sourced env vars (done inline by
+#      substituting values in igait-secrets itself).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: igait-pr-template
+
+resources:
+  - ../../k8s
+  - emulators/firebase/deployment.yaml
+  - emulators/firebase/service.yaml
+  - emulators/minio/deployment.yaml
+  - emulators/minio/service.yaml
+  - emulators/minio/bootstrap-job.yaml
+  - emulators/ses-mock/deployment.yaml
+  - emulators/ses-mock/service.yaml
+  - secrets/igait-secrets.yaml
+  - secrets/gcp-key.yaml
+
+# Remove the namespace resource from the base; the preview namespace is
+# created by ArgoCD (CreateNamespace=true sync option) with the right
+# PR-specific name.
+patches:
+  - target:
+      kind: Namespace
+      name: igait
+    patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: igait
+  # Delete the two ExternalSecrets from the base — the preview overlay
+  # supplies plain Secrets with the same names, so ESO isn't needed in
+  # the preview namespace at all.
+  - target:
+      kind: ExternalSecret
+      name: igait-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: external-secrets.io/v1beta1
+      kind: ExternalSecret
+      metadata:
+        name: igait-secrets
+  - target:
+      kind: ExternalSecret
+      name: gcp-key
+    patch: |-
+      $patch: delete
+      apiVersion: external-secrets.io/v1beta1
+      kind: ExternalSecret
+      metadata:
+        name: gcp-key
+  # Backend: inject POD_NAMESPACE via downward API.
+  - path: patches/backend-deployment.yaml
+    target:
+      kind: Deployment
+      name: backend

--- a/infra/overlays/preview/patches/backend-deployment.yaml
+++ b/infra/overlays/preview/patches/backend-deployment.yaml
@@ -1,0 +1,42 @@
+# Adds preview-only env vars to the backend container:
+#   - POD_NAMESPACE: read by orchestrator::pipeline_namespace() so Jobs
+#     land in *this* namespace (igait-pr-<N>) instead of the "igait"
+#     fallback. Sourced from the downward API so every pod gets its own
+#     ns — no hardcoding across replicas.
+#   - AWS_ENDPOINT_URL_{S3,SESV2}: aws-sdk-rust redirects to MinIO /
+#     ses-mock in-namespace instead of real AWS.
+#   - AWS_S3_FORCE_PATH_STYLE: virtual-host addressing tries to resolve
+#     `<bucket>.minio.<ns>.svc` which has no DNS record. Path-style
+#     (/minio/igait-storage) is the only thing that works against MinIO.
+#   - FIREBASE_AUTH_EMULATOR_HOST: the firebase-auth crate uses this
+#     signal to skip RS256 verification on emulator-issued JWTs. Without
+#     it, every login rejects with InvalidSignature.
+#
+# CORS_ALLOW_ORIGIN is intentionally omitted here — it depends on the
+# PR number (for the MagicDNS hostname) and is injected per-PR by the
+# ApplicationSet patches in slice 3 of #106.
+#
+# Strategic-merge merges env entries by `name`, so listing a new entry
+# appends it without touching the base's secretKeyRef env vars.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  template:
+    spec:
+      containers:
+        - name: backend
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: AWS_ENDPOINT_URL_S3
+              value: http://minio:9000
+            - name: AWS_ENDPOINT_URL_SESV2
+              value: http://ses-mock:8005
+            - name: AWS_S3_FORCE_PATH_STYLE
+              value: "true"
+            - name: FIREBASE_AUTH_EMULATOR_HOST
+              value: firebase-emulator:9099

--- a/infra/overlays/preview/secrets/gcp-key.yaml
+++ b/infra/overlays/preview/secrets/gcp-key.yaml
@@ -1,0 +1,23 @@
+# Stub GCP service-account JSON. The emulator ignores the credentials
+# entirely, but google-cloud libs insist on a file at
+# GOOGLE_APPLICATION_CREDENTIALS that parses as a service-account JSON.
+# The minimum viable shape is a JSON object with `type: "service_account"`
+# and a few dummy fields; the SDK never actually makes an auth call when
+# pointed at an emulator endpoint.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcp-key
+type: Opaque
+stringData:
+  gcp-key.json: |
+    {
+      "type": "service_account",
+      "project_id": "igait-local",
+      "private_key_id": "preview-stub",
+      "private_key": "-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----\n",
+      "client_email": "preview@igait-local.iam.gserviceaccount.com",
+      "client_id": "000000000000000000000",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token"
+    }

--- a/infra/overlays/preview/secrets/igait-secrets.yaml
+++ b/infra/overlays/preview/secrets/igait-secrets.yaml
@@ -1,0 +1,41 @@
+# Plain Secret with emulator-pointing literals — replaces the ESO-sourced
+# igait-secrets from the base for preview namespaces. None of these
+# values are actually secret (minioadmin/minioadmin are MinIO's compose
+# defaults, the Firebase creds are emulator dummies), but the backend
+# Deployment wires every env via secretKeyRef, so a Secret is the cheapest
+# drop-in.
+#
+# Keys MUST match the keys referenced in infra/k8s/backend/deployment.yaml
+# (secretKeyRef.key). If you add a new env var to the base that also
+# pulls from igait-secrets, add it here too or preview pods fail to
+# start with `CreateContainerConfigError`.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: igait-secrets
+type: Opaque
+stringData:
+  # Firebase → emulator. The ?ns=igait-local query string is load-bearing
+  # (FirebaseRtdb::url() merges its own ?auth= onto this); don't strip it.
+  FIREBASE_PROJECT_ID: igait-local
+  FIREBASE_ACCESS_KEY: local-emulator-key
+  FIREBASE_RTDB_URL: http://firebase-emulator:9000/?ns=igait-local
+  # AWS / S3 → MinIO. Endpoint overrides are injected as extra env vars
+  # by patches/backend-deployment.yaml (they're not in the base env list).
+  IGAIT_S3_BUCKET: igait-storage
+  AWS_REGION: us-east-2
+  AWS_ACCESS_KEY_ID: minioadmin
+  AWS_SECRET_ACCESS_KEY: minioadmin
+  # SES → ses-mock
+  SES_FROM_ADDRESS: noreply@preview.test
+  SES_FROM_IDENTITY_ARN: arn:aws:ses:us-east-2:000000000000:identity/local
+  # OpenAI: intentionally empty. The backend detects an empty
+  # OPENAI_API_KEY at boot, skips client init, and serves /assistant
+  # routes with 503. Previews don't burn prod tokens.
+  OPENAI_API_KEY: ""
+  OPENAI_ASSISTANT_ID: ""
+  OPENAI_VECTOR_STORE_ID: ""
+  # Path to the stub GCP key baked into the workspace runtime image.
+  # The Secret at /credentials/gcp-key.json shadows the baked file, so
+  # gcp-key.yaml below MUST provide a file under that same mount path.
+  GOOGLE_APPLICATION_CREDENTIALS: /credentials/gcp-key.json


### PR DESCRIPTION
## Summary

Slice 2b of #106 (per-PR preview environments). Bundles a small Rust change in the backend orchestrator with the full `infra/overlays/preview/` Kustomize overlay. Paired because neither is useful alone: the overlay is what injects `POD_NAMESPACE`, and the orchestrator change is what reads it.

### Rust: `pipeline_namespace()` replaces `const NAMESPACE = "igait"`

One backend image now serves both prod (`igait` ns) and every preview (`igait-pr-<N>` ns) without a rebuild — K8s Jobs land in whichever namespace the backend pod itself lives in.

Resolution order (OnceLock, resolved once at first use):
1. `POD_NAMESPACE` env var (downward API, injected by the overlay)
2. The kubelet-mounted `/var/run/secrets/kubernetes.io/serviceaccount/namespace` file (zero-config fallback in any pod)
3. Literal `"igait"` (preserves pre-existing behavior outside a cluster, e.g. `cargo run`)

Resolution logic sits in a pure `resolve_namespace(env, file)` fn so it's testable without touching real env/fs — 4 new tests cover the 3 sources + whitespace handling.

### Overlay: `infra/overlays/preview/`

```
infra/overlays/preview/
├── kustomization.yaml
├── emulators/
│   ├── firebase/{deployment,service}.yaml
│   ├── minio/{deployment,service,bootstrap-job}.yaml
│   └── ses-mock/{deployment,service}.yaml
├── secrets/{igait-secrets,gcp-key}.yaml
└── patches/backend-deployment.yaml
```

Notable decisions:
- **Lives at `infra/overlays/` not `infra/k8s/overlays/`** — kustomize rejects an overlay nested under its base with a "cycle detected" error. `infra/overlays/` is sibling to `infra/k8s/`; no impact on the existing ArgoCD app-of-apps which still syncs `infra/k8s`.
- **Plain `Secret` instead of `ExternalSecret`** for preview creds — `minioadmin` / `local-emulator-key` are MinIO + Firebase-emulator public defaults, not real secrets. Skipping ESO keeps SSM out of the preview blast radius.
- **`$patch: delete` on base `Namespace` + both base `ExternalSecret`s** — the ApplicationSet (slice 3) creates the per-PR namespace via `CreateNamespace=true`; ESO isn't wanted in preview namespaces.
- **Strategic-merge patch on backend env** appends `POD_NAMESPACE` (downward API) + `AWS_ENDPOINT_URL_S3/SESV2` + `AWS_S3_FORCE_PATH_STYLE` + `FIREBASE_AUTH_EMULATOR_HOST` without touching the base's `secretKeyRef` env vars (those still resolve via the overlay's replaced `igait-secrets`).

### Validation

```
$ kubectl kustomize infra/overlays/preview | grep -c '^kind:'
17   # RBAC + backend + frontend + 3 emulators + minio-bootstrap Job + 2 Secrets
```
- 0 `Namespace` (deleted)
- 0 `ExternalSecret` (deleted; replaced by plain Secrets)
- All resources land in `igait-pr-template` (placeholder; ApplicationSet rewrites per-PR)

```
$ kubectl kustomize infra/k8s | grep -c '^kind:'
10   # unchanged — no rendering impact on the base
```

## What's NOT in this slice

All in **slice 3**:
- ArgoCD `ApplicationSet` with the `PullRequest` generator
- Per-PR `namespace:` + `kustomize.images` patches on backend/frontend
- `STAGE_*_IMAGE` env-var patches (so stage changes in a PR exercise the PR's stage images rather than main's)
- Tailscale Service `LoadBalancer` patch (needs PR number for MagicDNS hostname)
- Per-PR `CORS_ALLOW_ORIGIN`
- `github-pr-token` ESO in the argocd namespace

## Test plan

- [x] `cargo test orchestrator::tests` — 4 new tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `kubectl kustomize infra/overlays/preview` renders cleanly, correct resource counts
- [x] `kubectl kustomize infra/k8s` unchanged (base still renders 10 resources, no cycle)
- [ ] End-to-end smoke: deferred to slice 3 merge — the ApplicationSet is what actually materializes a preview ns; this slice alone can't be exercised against a live cluster without manually hand-rolling `kubectl apply -k infra/overlays/preview` against a throwaway namespace.

Part of #106.