### PR TITLE
#106 (slice 3): ArgoCD ApplicationSet + github-pr-token ESO — PR previews live

### DIFF
--- a/infra/k8s/argocd/apps/applicationset-previews.yaml
+++ b/infra/k8s/argocd/apps/applicationset-previews.yaml
@@ -1,0 +1,126 @@
+# Per-PR preview environments — slice 3 of #106.
+#
+# Watches open PRs in igait-niu/igait and renders infra/overlays/preview/
+# per PR into a namespace `igait-pr-<N>`. The overlay handles the stack
+# shape (backend + frontend + emulators); this ApplicationSet handles
+# the per-PR substitutions (namespace, Tailscale hostname, CORS origin).
+#
+# No `labels:` filter on the PullRequest generator — every open PR gets
+# a preview automatically. Teardown on PR close is free via ArgoCD
+# `syncPolicy.automated.prune: true` reacting to the generator dropping
+# the PR from its rendered list.
+#
+# IMAGE TAG LIMITATION (known, tracked separately):
+#   Today, build-*.yml workflows only trigger on push to main, so no
+#   PR-specific image tags exist. `:latest` across the board means every
+#   preview renders *main's current state* under its per-PR URL —
+#   useful for "is main healthy? can I see last week's ship in a demo?"
+#   but it doesn't actually exercise the PR's code changes.
+#
+#   Once the follow-up (build-on-PR) feature ships, flip the image
+#   references here from `:latest` to `sha-{{head_short_sha}}` and
+#   update the STAGE_*_IMAGE env patch below likewise.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: igait-pr-previews
+  namespace: argocd
+spec:
+  generators:
+    - pullRequest:
+        github:
+          owner: igait-niu
+          repo: igait
+          tokenRef:
+            secretName: github-pr-token
+            key: token
+        requeueAfterSeconds: 120
+  template:
+    metadata:
+      name: 'igait-pr-{{number}}'
+      annotations:
+        igait.app/pr-number: '{{number}}'
+        igait.app/pr-branch: '{{branch}}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/igait-niu/igait
+        targetRevision: '{{branch}}'
+        path: infra/overlays/preview
+        kustomize:
+          namespace: 'igait-pr-{{number}}'
+          # Rewrites container image refs in rendered Deployments. Note:
+          # kustomize.images only touches `image:` fields, NOT env-var
+          # values — that's what the patches below are for (stage images
+          # live in backend's STAGE_*_IMAGE env vars, not its container
+          # image).
+          images:
+            - name: ghcr.io/igait-niu/igait/backend
+              newTag: latest
+            - name: ghcr.io/igait-niu/igait/frontend
+              newTag: latest
+            - name: ghcr.io/igait-niu/igait/firebase-emulator
+              newTag: latest
+          patches:
+            # Backend env: point stage images at :latest, and set
+            # CORS_ALLOW_ORIGIN to this PR's MagicDNS URL. Strategic
+            # merge appends-or-replaces by `name`; five stages plus the
+            # one CORS entry.
+            - target:
+                kind: Deployment
+                name: backend
+              patch: |-
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: backend
+                spec:
+                  template:
+                    spec:
+                      containers:
+                        - name: backend
+                          env:
+                            - name: STAGE_MEDIA_CONVERSION_IMAGE
+                              value: ghcr.io/igait-niu/igait/media-conversion:latest
+                            - name: STAGE_POSE_ESTIMATION_IMAGE
+                              value: ghcr.io/igait-niu/igait/pose-estimation:latest
+                            - name: STAGE_CYCLE_DETECTION_IMAGE
+                              value: ghcr.io/igait-niu/igait/cycle-detection:latest
+                            - name: STAGE_PREDICTION_IMAGE
+                              value: ghcr.io/igait-niu/igait/prediction:latest
+                            - name: STAGE_FINALIZE_IMAGE
+                              value: ghcr.io/igait-niu/igait/finalize:latest
+                            - name: CORS_ALLOW_ORIGIN
+                              value: 'https://igait-pr-{{number}}.igait-niu.org.github.ts.net'
+            # Frontend Service: expose via Tailscale with a per-PR
+            # MagicDNS hostname. The tailscale-operator reconciles
+            # loadBalancerClass: tailscale into a sidecar that
+            # advertises `igait-pr-<N>` on the tailnet; TLS is handled
+            # transparently by Tailscale's cert issuance.
+            - target:
+                kind: Service
+                name: frontend
+              patch: |-
+                apiVersion: v1
+                kind: Service
+                metadata:
+                  name: frontend
+                  annotations:
+                    tailscale.com/hostname: 'igait-pr-{{number}}'
+                    tailscale.com/tags: 'tag:k8s-igait'
+                spec:
+                  type: LoadBalancer
+                  loadBalancerClass: tailscale
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: 'igait-pr-{{number}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          # Stops ArgoCD from fighting the tailscale-operator over the
+          # Service's loadBalancer status, which the operator patches
+          # after creation.
+          - RespectIgnoreDifferences=true

--- a/infra/k8s/argocd/apps/github-pr-token-external-secret.yaml
+++ b/infra/k8s/argocd/apps/github-pr-token-external-secret.yaml
@@ -1,0 +1,35 @@
+# Materialises the `github-pr-token` Secret in the argocd namespace from
+# AWS SSM. Consumed by the `igait-pr-previews` ApplicationSet's
+# PullRequest generator to poll GitHub for open PRs.
+#
+# SSM parameter: `/igait/prod/github-pr-token`
+#   Type:        SecureString
+#   Value:       a GitHub PAT scoped to `public_repo` (or `repo` if
+#                igait-niu/igait ever goes private)
+#
+# Bootstrap (one-time, from the nix dev shell):
+#   aws ssm put-parameter \
+#     --name /igait/prod/github-pr-token \
+#     --type SecureString \
+#     --value "<paste PAT>"
+#
+# Rotation: update the SSM param; ESO's refreshInterval picks up the new
+# value within 5 min and overwrites the Secret in-place. The
+# ApplicationSet re-reads the token on its next reconcile (~2 min).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-pr-token
+  namespace: argocd
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-ssm
+  target:
+    name: github-pr-token
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        key: /igait/prod/github-pr-token


### PR DESCRIPTION
## Summary

Final slice of #106. Wires the preview machinery together end-to-end: an ArgoCD `ApplicationSet` with a `PullRequest` generator watches open PRs on `igait-niu/igait`, renders `infra/overlays/preview/` per PR into `igait-pr-<N>`, and — via ArgoCD's prune-on-remove — tears the namespace down when the PR closes.

### Files added

| Path | Purpose |
|------|---------|
| `infra/k8s/argocd/apps/applicationset-previews.yaml` | ApplicationSet w/ `PullRequest` generator, per-PR kustomize patches |
| `infra/k8s/argocd/apps/github-pr-token-external-secret.yaml` | ESO-materialised `github-pr-token` Secret in `argocd` ns from SSM |

### Per-PR substitutions (ApplicationSet → kustomize)

- `namespace: igait-pr-{{number}}`
- `images:` — backend/frontend/firebase-emulator → `:latest` (see limitation below)
- Backend env patch — STAGE_*_IMAGE → `:latest`, `CORS_ALLOW_ORIGIN → https://igait-pr-{{number}}.igait-niu.org.github.ts.net`
- Frontend Service patch — `type: LoadBalancer`, `loadBalancerClass: tailscale`, `tailscale.com/hostname: igait-pr-{{number}}`. The tailscale-operator reconciles this into a sidecar that advertises the MagicDNS name; TLS is handled automatically.

### Known limitation (tracked separately)

**All images default to `:latest`** because `build-*.yml` workflows only trigger on push to `main` — no per-PR image tags exist. Every preview therefore renders **main's current state** under its per-PR URL. Useful for "is main healthy?" and demo links; it does NOT yet exercise the PR's actual code changes.

Flipping to `sha-{{head_short_sha}}` is a one-line change in this file once build-on-PR lands. I'll open a follow-up issue for that feature.

## Prereq before merge

One-time bootstrap — the SSM param needs to exist before ArgoCD syncs:

```bash
aws ssm put-parameter \\
  --name /igait/prod/github-pr-token \\
  --type SecureString \\
  --value \"<GitHub PAT with public_repo scope>\"
```

Without it, the ExternalSecret will sit in `SecretSyncError`, the Secret won't materialise, and the ApplicationSet's PullRequest generator will fail to authenticate — no previews spin up, but nothing else breaks (prod is unaffected; the app-of-apps keeps syncing everything else).

## Test plan

Once merged + SSM param set:
- [ ] ArgoCD UI: `igait-pr-previews` ApplicationSet appears, starts generating `igait-pr-<N>` Applications for every open PR within ~2 min.
- [ ] Open a throwaway PR → watch `kubectl get ns | grep igait-pr`  → ns `igait-pr-<N>` materialises.
- [ ] All ~6 pods reach Ready (backend, frontend, firebase-emulator, minio, ses-mock, + minio-bootstrap Job completes).
- [ ] `https://igait-pr-<N>.igait-niu.org.github.ts.net` loads in a tailnet-connected browser.
- [ ] End-to-end: upload a video → finalize stage runs (under Jobs-mode orchestrator in preview ns) → email lands in the namespace's ses-mock.
- [ ] Close the PR → namespace drains within ~4 min (requeueAfterSeconds × 2).
- [ ] Open a second PR → second namespace spins up without disrupting the first.

Closes #106 (once verified on cluster).

## Ships with #106

- #141 — preview-comment workflow
- #144 — always-on (no label gate)
- #146 — firebase-emulator image publish
- #147 — preview overlay + orchestrator ns-dynamic
- **#TBD (this)** — ApplicationSet + ESO