### PR TITLE
#106 fixup: ApplicationSet kustomize.images must be strings

### DIFF
--- a/infra/k8s/argocd/apps/applicationset-previews.yaml
+++ b/infra/k8s/argocd/apps/applicationset-previews.yaml
@@ -54,13 +54,15 @@ spec:
           # values — that's what the patches below are for (stage images
           # live in backend's STAGE_*_IMAGE env vars, not its container
           # image).
+          #
+          # ArgoCD's Application CRD takes image overrides as strings
+          # ("name:newTag" or "name=newName:newTag"), NOT the
+          # {name, newTag} object form standalone kustomization.yaml
+          # files use. Different schema, same semantic intent.
           images:
-            - name: ghcr.io/igait-niu/igait/backend
-              newTag: latest
-            - name: ghcr.io/igait-niu/igait/frontend
-              newTag: latest
-            - name: ghcr.io/igait-niu/igait/firebase-emulator
-              newTag: latest
+            - ghcr.io/igait-niu/igait/backend:latest
+            - ghcr.io/igait-niu/igait/frontend:latest
+            - ghcr.io/igait-niu/igait/firebase-emulator:latest
           patches:
             # Backend env: point stage images at :latest, and set
             # CORS_ALLOW_ORIGIN to this PR's MagicDNS URL. Strategic


### PR DESCRIPTION
Immediate follow-up to #148 — the ApplicationSet was rejected by ArgoCD's admission webhook with a CRD schema error:

```
ApplicationSet.argoproj.io "igait-pr-previews" is invalid:
  spec.template.spec.source.kustomize.images[0]: Invalid value: "object":
    ... in body must be of type string: "object"
```

ArgoCD's Application CRD takes image overrides as **strings** (`name:newTag` or `name=newName:newTag`), not the `{name, newTag}` object form standalone `kustomization.yaml` files use. Different schema, same semantic intent — easy trap when copying syntax between the two.

## Changes

```yaml
# before
images:
  - name: ghcr.io/igait-niu/igait/backend
    newTag: latest
# after
images:
  - ghcr.io/igait-niu/igait/backend:latest
```

## Verified on cluster

Before: `kubectl get applicationset -n argocd` → `No resources found` (AppSet rejected by admission).
After merge: AppSet should be admitted and start generating Applications for each open PR within ~2 min.

## Still to bootstrap

Separate from this fix — the SSM param `/igait/prod/github-pr-token` also doesn't exist yet, so the ESO sync for `github-pr-token` is stuck in `SecretSyncedError`. User bootstrapping that in parallel.

Closes part of #106.