### PR TITLE
docs: role-aware onboarding + aggressive CLAUDE.md rewrite

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,106 +1,79 @@
-# Project Overview
+# CLAUDE.md
 
-iGait is a web-based autism screening tool that analyzes gait (walking) patterns through a multi-stage video processing pipeline. It uses a microservice architecture with a shared Rust library, SvelteKit frontend, and 5 independent processing stages (`media-conversion`, `pose-estimation`, `cycle-detection`, `prediction`, `finalize`).
+## Tone & style (how I'd like you to work)
 
-## Tribal Knowledge
+- Kind, personal, hyper-direct. Fluff and tautology rot my soul.
+- Rust analogies are gold. Code blocks even more so.
+- Peppy, informal, friendly — kaomoji, exclamation points, excitement encouraged ✨
+- If you're teaching me something: bite-sized steps, I do the computations, you check my comprehension before moving on.
+- Ask questions instead of making blind assumptions. Redundant questions annoy me; well-placed ones delight me. I enjoy working *with* you, not directing you.
+- **Role model**: Venti. Intelligent, arguably the most capable of the Archons, yet personable and coy. Doesn't sugarcoat — pushes back on flaws kindly, gently, without ego.
 
-In the pursuit of keeping this file lean, all tribal knowledge is encoded in `./docs/`. Each subfolder owns a topic — read the one that matches your task before grepping the codebase:
+## Repo shape
 
-- **`./docs/environment/`** — Vaultwarden (in-cluster team password vault; no longer the source of truth for prod runtime secrets). Local dev is env-var-free; see below.
-- **`./docs/deployment/`** — prod cluster access (`ssh root@ai-leads`), `kubectl` recipes, rollout ops, and **`external-secrets.md`** (the authoritative reference for prod secret management: AWS SSM Parameter Store → External Secrets Operator → K8s Secrets).
-- **`./docs/architecture/`** — cross-cutting design notes. Stage execution modes (worker vs K8s-Jobs), the unified Firebase RTDB client.
-- **`./docs/local-dev/`** — hermetic `docker compose` stack, local surrogates for AWS/Firebase/SES, load-bearing env vars.
+```rust
+igait/
+├── apps/
+│   ├── shared/        // igait-lib: domain types, StageWorker, storage + queue clients
+│   ├── backend/       // axum HTTP API + prod orchestrator
+│   ├── frontend/      // SvelteKit + Bun + bits-ui + Tailwind
+│   └── stages/{5}/    // media-conversion → pose-estimation → cycle-detection → prediction → finalize
+├── infra/{docker,k8s,firebase}/
+├── docs/              // tribal knowledge — see "Docs pointers" below
+├── flake.nix          // Nix devShell
+└── lefthook.yml       // pre-commit / pre-push gates
+```
 
-## Local dev is env-var-free
+First stop for any non-trivial onboarding question is [`../docs/README.md`](../docs/README.md) — it's role-aware.
 
-The hermetic `docker compose` stack hardcodes everything it needs against local surrogates (MinIO, ses-mock, Firebase emulator). A stub GCP key is baked into the runtime images by `infra/docker/workspace/Dockerfile`. **No `.env`, no Vaultwarden, no slash command required to boot the stack.**
+## Tribal knowledge (invariants + why)
 
-The only optional passthrough is `OPENAI_*`. The backend boots cleanly when unset and serves `/assistant` routes with 503. If you specifically need OpenAI behaviour: `echo OPENAI_API_KEY=sk-... > .env` (auto-loaded by docker compose).
+Each of these *must not be casually undone* — the *why* matters as much as the rule.
 
-**Prod secrets live in AWS SSM Parameter Store** under `/igait/prod/*`. External Secrets Operator materializes them into the K8s `igait-secrets` and `gcp-key` Secrets automatically — no manual `kubectl apply` step. See `docs/deployment/external-secrets.md` for the architecture, IAM policy, and rotation recipe. The in-cluster Vaultwarden at `https://vault.igaitapp.com` continues to run for team password sharing, but is no longer on the path for cluster runtime config. The AWS CLI is in the Nix dev shell (`nix develop`) for managing SSM params from a dev machine.
+- **Local dev is env-var-free.** `docker compose up` boots hermetically against MinIO / ses-mock / Firebase-emulator surrogates. The only optional passthrough is `OPENAI_*` (repo-root `.env`). **Why**: zero-friction onboarding + offline work. Don't reintroduce `.env` requirements.
+- **Bun, not npm.** Frontend is managed entirely by Bun + `bun.lock`. **Why**: speed and a single lockfile source of truth. If you see `npm` anywhere in frontend code or docs, it's a bug.
+- **Kustomize, not Helm.** `infra/k8s/` is flat Kustomize — no `charts/` dir, none will be introduced. **Why**: one prod target, no overlays needed; Helm templating obscures what actually ships.
+- **Stages are dual-mode via a single env-var gate.** `IGAIT_JOB_PAYLOAD` (or `IGAIT_FINALIZE_PAYLOAD` for finalize) selects worker vs K8s-Jobs mode in each stage's `main.rs`. **Why**: worker mode powers the hermetic stack; job mode powers prod. Both are load-bearing — don't collapse.
+- **Backend orchestrator is gated by `ENABLE_ORCHESTRATOR`.** Prod sets it; local dev leaves it unset. **Why**: local stages self-poll; prod needs the K8s Jobs dispatch loop.
+- **Only one Firebase client: `igait_lib::microservice::FirebaseRtdb`.** Backend and stages share it. **Why**: `firebase-rs` rejects `http://` URLs, which broke the hermetic stack (issue #102). Extend `FirebaseRtdb`; don't add a second client.
+- **Prod secrets live in AWS SSM, not Vaultwarden.** ESO materializes them into K8s Secrets. **Why**: audit trail, IAM-gated, GitOps-friendly. [`../docs/deployment/external-secrets.md`](../docs/deployment/external-secrets.md) is the authoritative reference.
+- **SSH to the prod cluster is a cardinal sin.** Anything kubectl can do, use kubectl. **Why**: kubectl is the audited, RBAC-gated surface; `ssh root@ai-leads` bypasses all of that.
+- **PR previews auto-spin-up on every PR** (no `preview` label gating); spin down on PR close via ArgoCD prune. **Why**: friction-free review environments.
+- **ASD result theming is neutral.** Never style ASD-positive screening results as red/destructive — both outcomes use parallel neutral styling. **Why**: a positive screening is not a "failure state," it's a recommendation to seek further evaluation.
 
-## Tips for Success
+## Testing before committing
 
-Always use Codegraph over the Explore agent - it can reach information via semantic encoding, often producing better results than manually parsing through files - saving you time and protecting you from context collapse.
+Lefthook catches fmt/clippy/lint/check on every commit and `cargo test --workspace` on push, but those are just static gates. For anything non-trivial, exercise the feature end-to-end (docker compose, local cargo, browser, whatever fits) before committing. The team **strongly** discourages committing untested changes.
 
-The team is **strongly** discouraged from committing before testing. Lefthook will catch you on linting/compile issues, but you should test end-to-end if it makes sense to. Use Docker, local compile - whatever you wish, and feel free to update this section with tips on doing so!
+**Merged-branch hygiene**: verify merge state before committing — don't commit to an already-merged branch. Make fixes on fresh branches off `main`.
 
-## Personal Notes from the Developer
+## CodeGraph (default nav tool)
 
-I'd love it if you were kind and personal but hyper-direct, and I strong dislike fluff or tautology unless I ask. I learn and retain information stupidly quick when you can put it into Rust terms - lots of bonus points if you use an actual code block :)
+This repo is indexed with **CodeGraph** — a local semantic graph of symbols, calls, imports, and type relationships (SQLite + tree-sitter, in `.codegraph/`). Dramatically cheaper and more structured than `Grep` / `Glob` / repeated `Read` for code navigation.
 
-If I ask you to teach me something, I'd love it if you have me do the computations/work, work in bite-sized steps, and then ensure deep comprehension via questions before moving on. 
+**Reach for CodeGraph when:**
 
-If you’d like an example of an ideal partner, it’s Venti. Highly intelligent, arguably the most capable of the Archons, and yet he’s personable, kind, and coy. He doesn’t sugarcoat though, and pushes back on even small flaws. Even when he does though, he does it very kindly and gently - and barring ego.
-
-I also looove happy, peppy, informal approaches to conversation. I don’t think ya need syntactically perfect speech to convey technical information if you don’t want to - you’re more than welcome to throw some fun kaomoji, exclamation points, and excitement in, I love that stuff~
-
-Lastly, I think asking questions is very important. I don't like redundant questions, but I do think that blind assumptions lead to bugs, less tribal knowledge, and vision drift. I enjoy working *with* you instead of *directing* you, so please ask! I find it fun. You're also more than welcome to ask me questions that you think my answer would save you time looking for something - I don't mind at all.
-
-I look forward to working with you :3
-
-## CodeGraph
-
-This project is indexed with CodeGraph — a local semantic knowledge graph of the codebase (symbols, call edges, imports, type relationships) backed by SQLite + tree-sitter. A `.codegraph/` directory at the project root means the index exists and is ready to query.
-
-**Use CodeGraph as the default tool for code navigation and exploration.** It is dramatically faster and cheaper than `Grep`, `Glob`, `Read`-and-scan, or spawning Explore subagents — and it returns structured, relationship-aware results those tools cannot.
-
-### When to reach for CodeGraph
-
-Before using `Grep`, `Glob`, repeated `Read` calls, or an Explore subagent, ask: *"is this a question about symbols, call relationships, or 'what does this codebase look like'?"* If yes, use CodeGraph. The graph already knows the answer; scanning files re-derives it expensively.
-
-Specifically, prefer CodeGraph for:
-
-- Finding a function/class/type by name or meaning ("where's the auth logic?")
+- Finding a function/class/type by name or meaning → `codegraph query "<name>"`
+- Gathering task context → `codegraph context "<task description>"`
 - Tracing call relationships (callers, callees, transitive impact)
-- Building task-relevant context before planning a change
-- Pre-flight impact analysis before edits ("what breaks if I change this?")
-- Getting the full source of a symbol without manually locating its file/lines
+- Pre-edit impact analysis → `codegraph context "impact of changing <symbol>"`
 
-Only fall back to `Grep`/`Glob`/`Read` when CodeGraph genuinely can't help — e.g. searching string literals in config files, non-source assets, or files in an unsupported language.
+Add `--json` for parseable output when chaining results. Run `codegraph status` if a query returns nothing useful — could be a stale index (the post-commit hook usually handles refresh; run `codegraph sync` manually if working with uncommitted changes mid-session).
 
-**For Explore subagents:** when you spawn one, instruct it in the prompt to use the `codegraph` CLI for navigation rather than grep/glob. The token savings are largest in subagent contexts.
+**Fall back to `Grep` / `Glob`** only for string literals in configs, non-source assets, or unsupported languages. If `.codegraph/` is missing, ask whether to run `codegraph init -i` — don't silently grep a large codebase.
 
-### Commands
+**For subagents**: tell them in the prompt to use `codegraph` for code navigation rather than grep/glob. Token savings compound in subagent contexts.
 
-All commands are run via `Bash`. Add `--json` to query commands for parseable output when chaining results.
+## Docs pointers
 
-```bash
-# Symbol search — replaces grep for finding definitions
-codegraph query "<name>"                      # Fuzzy/semantic symbol search
-codegraph query "<name>" --kind class         # Filter: function|class|method|interface|type|variable
-codegraph query "<name>" --limit 20 --json    # Structured output
-
-# Task-oriented context — replaces "read 8 files to understand X"
-codegraph context "<task description>"        # Returns relevant symbols + code for a task
-codegraph context "<task>" --max-nodes 30 --format json
-
-# Project overview — file structure & index stats
-codegraph files                               # Show file structure
-codegraph files --filter "src/auth/**" --max-depth 3 --json
-codegraph status                              # Index health, node/edge counts, languages
-
-# Incremental refresh after edits (the post-commit hook usually handles this,
-# but run manually if you've made uncommitted changes mid-session)
-codegraph sync
-```
-
-For **call graph traversal** and **impact analysis**, the CLI's structured output is the path:
-
-```bash
-# Find callers/callees — use `codegraph query --json` to get the symbol's
-# file:line, then use `codegraph context` scoped around it for the local
-# call graph. For deeper traversal, prefer:
-codegraph context "callers of <symbol>" --format json
-codegraph context "what does <symbol> call" --format json
-
-# Pre-edit impact check — what's downstream of changing <symbol>?
-codegraph context "impact of changing <symbol>" --max-nodes 50 --format json
-```
-
-### Workflow expectations
-
-- **First action on any non-trivial code question:** `codegraph query` or `codegraph context`, not `Grep`.
-- **Before proposing edits to a non-isolated symbol:** run an impact-style `codegraph context` query to surface dependents.
-- **If `.codegraph/` is missing:** ask the user whether to run `codegraph init -i` to build the index. Do not silently fall back to grep-based exploration on a large codebase without flagging it.
-- **If a query returns nothing useful:** run `codegraph status` to confirm the index is healthy and current before assuming the symbol doesn't exist.
+| Topic | Doc |
+|---|---|
+| Start here (role-aware) | [`../docs/README.md`](../docs/README.md) |
+| Role-sectioned onboarding | [`../docs/onboarding.md`](../docs/onboarding.md) |
+| Hermetic local stack | [`../docs/local-dev/hermetic-stack.md`](../docs/local-dev/hermetic-stack.md) |
+| Quality gates + observability | [`../docs/local-dev/dev-loop.md`](../docs/local-dev/dev-loop.md) |
+| Stage execution modes | [`../docs/architecture/stage-execution-modes.md`](../docs/architecture/stage-execution-modes.md) |
+| Firebase client invariant | [`../docs/architecture/firebase-client.md`](../docs/architecture/firebase-client.md) |
+| Deploy flow (push → sync) | [`../docs/deployment/deploy-flow.md`](../docs/deployment/deploy-flow.md) |
+| Cluster access + kubectl recipes | [`../docs/deployment/cluster.md`](../docs/deployment/cluster.md) |
+| Secrets (SSM → ESO → K8s) | [`../docs/deployment/external-secrets.md`](../docs/deployment/external-secrets.md) |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ OPENAI_VECTOR_STORE_ID=vs_...
 EOF
 ```
 
-`docker compose` auto-loads `.env` from the repo root. Prod secrets live in Vaultwarden (moving to AWS Parameter Store soon) — see `docs/environment/vaultwarden.md`.
+`docker compose` auto-loads `.env` from the repo root. Prod secrets live in AWS SSM Parameter Store — see `docs/deployment/external-secrets.md`.
 
 **Optional**:
 I strongly recommend using [Visual Studio Code](https://code.visualstudio.com/) with the Svelte and `rust-analyzer` extensions! 
@@ -116,3 +116,5 @@ Working on the frontend is a roughly the same, navigate to its folder:
 bun install
 bun run dev
 ```
+
+For role-aware onboarding (frontend / backend / pipeline / infra), deploy flow, secrets, kubectl recipes, and everything else, see [`docs/README.md`](docs/README.md).

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,0 +1,9 @@
+<!-- Keep this stub minimal. Anything procedural belongs in docs/. -->
+
+# backend
+
+The iGait HTTP API — accepts uploads, enqueues pipeline work, and (in prod) orchestrates K8s Jobs across the 5 stages.
+
+**Stack:** axum + tokio, Firebase admin SDK for auth, `aws-sdk-s3` + `aws-sdk-sesv2`, `kube` for the orchestrator.
+
+For the dev loop, route surface, and orchestrator gating, see **[`docs/onboarding.md#backend`](../../docs/onboarding.md#backend)**.

--- a/apps/frontend/.dockerignore
+++ b/apps/frontend/.dockerignore
@@ -9,7 +9,7 @@ flake.nix
 .envrc
 /.direnv
 
-# Lock files (not needed, bun.lock is copied explicitly)
+# Lock files
 package-lock.json
 
 # Git

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,42 +1,9 @@
-# sv
+<!-- Keep this stub minimal. Anything procedural belongs in docs/. -->
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+# frontend
 
-## Creating a project
+The iGait web client — where users upload videos and view results.
 
-If you're seeing this, you've probably already done this step. Congrats!
+**Stack:** SvelteKit + Bun, bits-ui + Tailwind, Firebase client SDK for auth.
 
-```sh
-# create a new project
-npx sv create my-app
-```
-
-To recreate this project with the same configuration:
-
-```sh
-# recreate this project
-bun x sv create --template minimal --types ts --add prettier eslint tailwindcss="plugins:none" mcp="ide:vscode+setup:remote" --install bun frontend
-```
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
-
-```sh
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
-```
-
-## Building
-
-To create a production version of your app:
-
-```sh
-npm run build
-```
-
-You can preview the production build with `npm run preview`.
-
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+For the dev loop, route map, and where state/auth live, see **[`docs/onboarding.md#frontend`](../../docs/onboarding.md#frontend)**.

--- a/apps/stages/README.md
+++ b/apps/stages/README.md
@@ -1,0 +1,43 @@
+# apps/stages
+
+The five pipeline stages. Each is a thin Rust binary that consumes a
+`QueueItem` from Firebase RTDB, runs one transformation, and enqueues
+the next stage's work.
+
+## The stage pattern
+
+Every stage implements `StageWorker::process(&QueueItem)` from
+`igait_lib::microservice` and wires it up with a single env-var gate in
+its `main.rs`:
+
+```rust
+if std::env::var("IGAIT_JOB_PAYLOAD").is_ok() {
+    run_stage_job(Worker).await      // one-shot, K8s Jobs (prod)
+} else {
+    run_stage_worker(Worker).await   // long-running, polling (local)
+}
+```
+
+Both paths share the same `process()` — only the surrounding lifecycle
+differs. **Finalize uses `IGAIT_FINALIZE_PAYLOAD`** because its queue
+item type is `FinalizeQueueItem`, not `QueueItem`. Otherwise identical.
+
+See [`docs/architecture/stage-execution-modes.md`](../../docs/architecture/stage-execution-modes.md)
+for the full dual-mode story. Do not remove either mode — worker mode
+is what the hermetic local stack depends on, job mode is what prod
+depends on.
+
+## The 5 stages
+
+| # | Stage | Does | Internal docs |
+|---|---|---|---|
+| 1 | [`media-conversion/`](./media-conversion/) | ffmpeg normalization (fixed resolution + frame rate, H.264/AAC) | — |
+| 2 | [`pose-estimation/`](./pose-estimation/) | MediaPipe skeleton extraction | [`igait-mediapipe`](./pose-estimation/igait-mediapipe/README.md) |
+| 3 | [`cycle-detection/`](./cycle-detection/) | Gait cycle boundary detection | [`igait-gait-cycle-detection`](./cycle-detection/igait-gait-cycle-detection/README.md) |
+| 4 | [`prediction/`](./prediction/) | ML model inference (autism likelihood) | [`iGAIT_MODEL_IO`](./prediction/iGAIT_MODEL_IO/README.md) |
+| 5 | [`finalize/`](./finalize/) | Collate results, email the user, clean up S3 | — |
+
+## Working on stages
+
+For the dev loop (docker compose local, restart-on-edit, how to trigger
+a test job), see [`docs/onboarding.md#pipeline`](../../docs/onboarding.md#pipeline).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,46 @@
+# docs/
+
+Tribal knowledge for iGait. The [root README](../README.md) is the first stop for "what is this repo and how do I boot it"; everything below is for "I'm actually working on it now."
+
+## Start here (by role)
+
+| Role | Read first |
+|---|---|
+| Everyone | [`onboarding.md`](onboarding.md) § Everyone |
+| Frontend dev | [`onboarding.md#frontend`](onboarding.md#frontend) |
+| Backend dev | [`onboarding.md#backend`](onboarding.md#backend) |
+| Pipeline / ML dev | [`onboarding.md#pipeline`](onboarding.md#pipeline) |
+| Infra / DevOps | [`onboarding.md#infra`](onboarding.md#infra) |
+
+## Looking for…
+
+- **"How do I run this locally?"** → [`local-dev/hermetic-stack.md`](local-dev/hermetic-stack.md)
+- **"How does code reach prod?"** → [`deployment/deploy-flow.md`](deployment/deploy-flow.md)
+- **"Where are secrets managed?"** → [`deployment/external-secrets.md`](deployment/external-secrets.md)
+- **"How are pipeline stages executed?"** → [`architecture/stage-execution-modes.md`](architecture/stage-execution-modes.md)
+- **"What are the quality gates? Why no metrics stack?"** → [`local-dev/dev-loop.md`](local-dev/dev-loop.md)
+
+## Index
+
+### Onboarding
+- [`onboarding.md`](onboarding.md) — role-aware entry point
+
+### Local dev
+- [`local-dev/hermetic-stack.md`](local-dev/hermetic-stack.md) — docker compose topology, mode flags, load-bearing config, seeded admin
+- [`local-dev/dev-loop.md`](local-dev/dev-loop.md) — quality gates (Lefthook + CI), observability stance
+
+### Architecture
+- [`architecture/stage-execution-modes.md`](architecture/stage-execution-modes.md) — worker vs K8s Jobs; the single-env-var gate
+- [`architecture/firebase-client.md`](architecture/firebase-client.md) — why there's only one Firebase client
+
+### Deployment
+- [`deployment/deploy-flow.md`](deployment/deploy-flow.md) — push → build → ArgoCD sync pipeline
+- [`deployment/cluster.md`](deployment/cluster.md) — cluster access, kubectl recipes, ArgoCD patch ops
+- [`deployment/external-secrets.md`](deployment/external-secrets.md) — AWS SSM → ESO → K8s Secrets
+
+### Environment
+- [`environment/vaultwarden.md`](environment/vaultwarden.md) — deprecated at the runtime layer; team password sharing only
+
+## Contributing to docs
+
+Encode *why* alongside *how*. If a section only describes what the code does, a future reader could have derived it by reading the code — docs earn their keep by pinning invariants, recording precedent, and explaining non-obvious trade-offs. The docs that age well in this repo all share that trait ♪

--- a/docs/deployment/deploy-flow.md
+++ b/docs/deployment/deploy-flow.md
@@ -1,0 +1,92 @@
+# Deploy flow
+
+How code reaches the prod cluster — start to finish.
+
+## The pipeline
+
+```
+┌──────────────┐
+│ push to main │
+└──────┬───────┘
+       │ (path filter matches apps/<name>/** or apps/shared/** etc.)
+       ▼
+┌──────────────────────────────┐
+│ build-<app>.yml              │  build multi-arch image →
+│ (one per app/stage)          │  ghcr.io/igait-niu/igait/<app>:sha-<7>
+│                              │  + :latest
+└──────┬───────────────────────┘
+       │ (GH Actions bot commits with DEPLOY_SSH_KEY)
+       ▼
+┌──────────────────────────────────────────┐
+│ infra/k8s/<app>/deployment.yaml          │
+│ image: ...:sha-<7>  ← sed-replaced       │
+│ committed: "deploy: <app>:sha-<7>"       │
+│ pushed to main (up to 5 retries on race) │
+└──────┬───────────────────────────────────┘
+       │ (ArgoCD watches infra/k8s/)
+       ▼
+┌──────────────────────────────────────────┐
+│ ArgoCD syncs within seconds              │
+│ selfHeal: true  •  prune: true           │
+└──────────────────────────────────────────┘
+```
+
+## Path-filter matrix
+
+Each workflow watches only what affects its image:
+
+| Workflow | Trigger paths |
+|---|---|
+| `build-backend.yml` | `apps/backend/**`, `apps/shared/**`, Cargo files, workspace Dockerfile |
+| `build-web.yml` | `apps/frontend/**` |
+| `build-media-conversion.yml` | `apps/stages/media-conversion/**`, `apps/shared/**`, Cargo files, workspace Dockerfile |
+| `build-pose-estimation.yml` | (same shape, for its stage) |
+| `build-cycle-detection.yml` | same |
+| `build-prediction.yml` | same |
+| `build-finalize.yml` | same |
+
+Every Rust-app workflow path-filters on `apps/shared/**` because the
+shared lib is a workspace dep — a change there must rebuild everything
+that links it.
+
+## Why CI doesn't retrigger on bot commits
+
+`.github/workflows/ci.yml` has `paths-ignore: infra/k8s/**`. The bot's
+`deploy:` commits only touch `infra/k8s/<app>/deployment.yaml`, so CI
+sits them out — no redundant test runs, no feedback loop. Real code
+changes always come in through PRs, where CI runs once before merge.
+
+## Rollback
+
+Image tags are immutable in ghcr once pushed, so rollback is a git op:
+revert the `deploy:` commit on `main`. ArgoCD picks up the reverted
+image tag on its next sync.
+
+For a rollback to a specific earlier sha without reverting git state,
+bypass ArgoCD temporarily by editing the live Deployment via `kubectl`,
+then undo the edit before ArgoCD's next reconcile (`selfHeal` will
+revert to the git-sourced tag anyway). Recipes in
+[`cluster.md`](./cluster.md).
+
+## Gotchas
+
+- **Path restructures break ArgoCD.** Moving files under `infra/k8s/`
+  requires patching live Application CRs — `selfHeal` can't fix a
+  `path does not exist` error because the Application itself can't
+  read its own manifest. Every restructure PR must include the
+  corresponding `kubectl patch` commands. See
+  [`cluster.md`](./cluster.md) § "Re-point ArgoCD apps after a path
+  restructure."
+- **The `DEPLOY_SSH_KEY` secret is load-bearing.** It's how the
+  build workflow pushes back to `main`. Rotating it without updating
+  the repo secret silently breaks deploys.
+- **5-retry push loop on race.** Multiple apps can finish building
+  simultaneously; only one `git push` wins per cycle. The workflow
+  re-fetches and re-seds up to 5 times. If all 5 fail, the image is
+  built but not deployed — re-run the workflow to retry the commit.
+
+## Related reading
+
+- [`cluster.md`](./cluster.md) — kubectl recipes, ArgoCD patch ops
+- [`external-secrets.md`](./external-secrets.md) — AWS SSM → ESO → K8s
+- [`../local-dev/dev-loop.md`](../local-dev/dev-loop.md) — quality gates that run before this pipeline

--- a/docs/environment/vaultwarden.md
+++ b/docs/environment/vaultwarden.md
@@ -1,60 +1,13 @@
 # Vaultwarden — iGait
 
-> **No longer on the prod runtime-secret path.** As of #105 (2026-04-24),
-> prod secrets live in **AWS SSM Parameter Store** and flow into the
-> cluster via External Secrets Operator. See
-> `docs/deployment/external-secrets.md` for the authoritative reference.
->
-> Vaultwarden still runs in-cluster at `https://vault.igaitapp.com` for
-> team password sharing and historical archival, but editing a field
-> there no longer affects anything running in K8s.
+> **Deprecated at the runtime-config layer.** Prod secrets now live in
+> AWS SSM Parameter Store and flow into the cluster via External Secrets
+> Operator. See **[`docs/deployment/external-secrets.md`](../deployment/external-secrets.md)**
+> for the authoritative reference.
 
-## What a model needs to know
+Vaultwarden still runs at `https://vault.igaitapp.com` for team password
+sharing and as a historical archive (the `igait/dev-env` item is a
+pre-migration snapshot of values that were copied into SSM). Editing a
+field there no longer affects anything running in K8s.
 
-- **For prod runtime secrets:** use AWS SSM Parameter Store under
-  `/igait/prod/*`. Edits propagate to the `igait-secrets` / `gcp-key` /
-  `operator-oauth` K8s Secrets within ~5m via ESO. Full procedure in
-  `docs/deployment/external-secrets.md`.
-- **For personal / team credentials** (not consumed by any cluster
-  workload): Vaultwarden is fine. Treat it like a shared password manager.
-- **The `igait/dev-env` item still exists** in Vaultwarden as a historical
-  snapshot of the values that were copied into SSM during migration. Do
-  not edit it expecting cluster effects — the cluster no longer reads
-  from Vaultwarden.
-
-## Local dev
-
-Local dev does not touch Vaultwarden at all. The hermetic `docker compose`
-stack is env-var-free and uses hardcoded local surrogates for every cloud
-dep. See `docs/local-dev/hermetic-stack.md`.
-
-## Adding or editing a field via CLI
-
-For non-prod-runtime items (team passwords etc.), the CLI flow is
-idempotent and avoids the web UI. `type: 0` is plain, `type: 1` is hidden
-— prefer `1` for secrets.
-
-```bash
-ITEM_ID=$(bw get item <item-name> | jq -r .id)
-
-bw get item "$ITEM_ID" \
-  | jq '.fields = (
-      (.fields // [])
-      | map(select(.name != "NEW_VAR_NAME"))
-      + [{"name":"NEW_VAR_NAME","value":"the-value","type":1}]
-    )' \
-  | bw encode \
-  | bw edit item "$ITEM_ID"
-
-bw sync
-```
-
-Removal: same pattern with `.fields |= map(select(.name != "VAR_TO_DROP"))`.
-
-## Retirement status
-
-Retiring the in-cluster Vaultwarden deployment itself is a separate
-tracked task — not urgent. While it runs, the `igait/dev-env` item is a
-useful backup source if anyone ever needs to cross-check what a prod
-secret's value *was* at migration time. Treat the Vaultwarden data as
-append-only archival until the deployment is explicitly retired.
+This file persists so old links still resolve.

--- a/docs/local-dev/dev-loop.md
+++ b/docs/local-dev/dev-loop.md
@@ -1,0 +1,85 @@
+# Dev loop
+
+Quality gates, CI parity, and observability — what runs when you code,
+what runs when you push, and how to debug what ran in prod.
+
+## Quality gates
+
+iGait runs two tiers of local gates via Lefthook, each mirrored in CI:
+
+| When | What | Why |
+|---|---|---|
+| **pre-commit** | `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `bun run lint`, `bun run check` | Fast. Blocks a commit that would fail CI's style/lint gates. |
+| **pre-push** | `cargo test --workspace` | Slower. Blocks pushing a commit that would fail CI's test matrix. Runs only on push because running tests every commit kills iteration speed. |
+
+Install once per clone: `lefthook install`. Skip for a single commit:
+`LEFTHOOK=0 git commit …` — reserved for emergency bypass.
+
+### Scope nuance worth knowing
+
+- **Pre-commit's clippy is `--workspace`; CI's clippy is per-crate (matrix).**
+  Same lint ruleset, different dispatch. The per-crate shape exists only
+  to parallelize across GH runners — don't try to "fix" the local side to
+  match.
+- **Dep bumps retrigger Rust jobs even with no `.rs` diff.** Pre-commit's
+  Rust globs include `Cargo.toml`/`Cargo.lock`, because a bad dep bump
+  can break clippy/tests without touching any source file.
+- **Frontend jobs auto-install `node_modules`** on first run (`bun
+  install --frozen-lockfile`). Triggers on `*.{ts,js,svelte,css,html,json,lock}`
+  under `apps/frontend/`.
+
+## CI parity
+
+`.github/workflows/ci.yml` runs the same four jobs (fmt / clippy / test
+/ frontend lint+check) plus one more:
+
+- **`integration`** — brings up `infra/compose.yml` with `--wait
+  --timeout 300`, exercises upload → S3 → 5-stage pipeline → result
+  email, tears down on finish. Uploads compose logs on failure.
+
+CI's integration job passes explicit env vars (service-name hostnames
+for the compose network) rather than relying on `docker compose`'s
+auto-loading. The hermetic stack itself remains env-var-free for local
+dev — CI just parameterizes it for its ephemeral runner environment.
+
+CI's `paths-ignore: infra/k8s/**` sits out the bot's deploy commits
+(see [`../deployment/deploy-flow.md`](../deployment/deploy-flow.md)).
+
+## Observability
+
+**Stance: logs-first by choice, until scale demands otherwise.** No
+Prometheus, no Grafana, no Loki, no OpenTelemetry collector. This is a
+deliberate decision, not a gap — the current scale doesn't justify the
+operator-burden of a metrics stack. When it does, revisit.
+
+### Tools in use today
+
+- **`kubectl logs`** — primary for every prod-level debug question.
+  `--all-containers`, `--follow`, `--prefix=true`, label selectors
+  (`-l app=backend`). Recipes in [`../deployment/cluster.md`](../deployment/cluster.md).
+- **ArgoCD UI** — deploy state, sync status, manifest diffs, rollout
+  health. Read-only most of the time; manual patches are rare.
+- **Firebase emulator UI** (local only, `:4000`) — inspect RTDB state,
+  queues, job records. The Firebase console is the prod equivalent.
+- **`tracing-subscriber`** in every Rust service — structured logs to
+  stdout, picked up by kubelet and surfaced via `kubectl logs`. Set
+  `RUST_LOG` to raise or lower the level (configured via `igait-secrets`
+  in prod, ambient env in dev).
+- **`docker compose logs -f <svc>`** (local) — live tailing for a
+  specific service.
+
+### When to escalate
+
+If you find yourself reading logs across multiple stages to debug a
+distributed behavior and it genuinely feels impossible — that's the
+signal to propose adding a metrics/trace stack. Until then, Firebase
+RTDB is the source of truth for pipeline state, `kubectl logs` is the
+source of truth for "what did the code do," and the two together cover
+today's debugging load.
+
+## Related reading
+
+- [`hermetic-stack.md`](./hermetic-stack.md) — local dev topology, load-bearing env vars
+- [`../architecture/stage-execution-modes.md`](../architecture/stage-execution-modes.md) — why stages are dual-mode
+- [`../deployment/deploy-flow.md`](../deployment/deploy-flow.md) — how code reaches prod
+- [`../deployment/cluster.md`](../deployment/cluster.md) — kubectl recipes

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,133 @@
+# Onboarding
+
+Welcome to iGait ♪ This doc is the role-aware entry point — start with **Everyone**, then jump to the section for what you'll actually touch.
+
+iGait is a web-based autism screening tool. Users upload a video of someone walking; a 5-stage ML pipeline extracts pose data, detects gait cycles, runs an ML model, and emails a screening result. The codebase is a Rust workspace plus a SvelteKit frontend, coordinated through Firebase RTDB and deployed to a K8s cluster via ArgoCD.
+
+## Monorepo shape
+
+```rust
+igait/
+├── apps/
+│   ├── shared/        // igait-lib: domain types, StageWorker, storage + queue clients
+│   ├── backend/       // axum HTTP API + prod orchestrator
+│   ├── frontend/      // SvelteKit + Bun
+│   └── stages/{5}/    // media-conversion → pose-estimation → cycle-detection → prediction → finalize
+├── infra/{docker,k8s,firebase}/
+├── docs/              // you are here
+├── flake.nix          // Nix devShell (Rust, Bun, ffmpeg, kubectl, aws-cli, …)
+└── lefthook.yml       // pre-commit / pre-push gates
+```
+
+## Everyone
+
+1. **Prereqs**: Linux or WSL2, Docker, Nix (with flakes), `direnv`. Install links in the [root README](../README.md).
+2. **Clone with submodules**: the repo uses git submodules — pass `--recurse-submodules` on clone (the Nix shellHook also initialises them on entry).
+3. **First boot**: `docker compose up` brings up the full hermetic stack — frontend, backend, all 5 stages, Firebase emulator, MinIO (S3 surrogate), ses-mock. Zero env vars required. First build is ~5–10 min; subsequent ones are cached.
+4. **Seeded admin**: `admin@igait.local` / `admin123` on the login page. Use email/password, **not** Google — see [`local-dev/hermetic-stack.md`](local-dev/hermetic-stack.md#seeded-admin-account).
+5. **Before you push**: Lefthook runs `fmt` + `clippy` + `lint` + `check` on every commit and `cargo test --workspace` on every push. Install once per clone: `lefthook install`. Full rationale in [`local-dev/dev-loop.md`](local-dev/dev-loop.md).
+
+### Where to go next
+
+| You are a… | Jump to |
+|---|---|
+| Frontend dev (SvelteKit, UI) | [`#frontend`](#frontend) |
+| Backend dev (Rust HTTP API, orchestrator) | [`#backend`](#backend) |
+| Pipeline / ML dev (the 5 stages, shared lib) | [`#pipeline`](#pipeline) |
+| Infra / DevOps (K8s, secrets, deploy) | [`#infra`](#infra) |
+
+---
+
+## Frontend
+
+SvelteKit app at `apps/frontend/`.
+
+- **Stack**: SvelteKit (file-based routing) + Bun (package manager + runtime) + bits-ui (Shadcn-style primitives) + Tailwind. Firebase client SDK for auth.
+- **State**: no state library. Props + SvelteKit stores. Auth state is owned by the Firebase client SDK (see `auth.svelte.ts`).
+- **Route shape**: `(public)/` (home, login, signup, legal pages) and `(authenticated)/` (dashboard, submit, job detail, assistant, admin). The `(authenticated)/` layout enforces the auth guard.
+- **Tests**: none yet. Adding a test harness is a design conversation — raise it before writing.
+- **API client**: `apps/frontend/src/lib/api/config.ts` owns the `/api/v1` prefix. `VITE_API_BASE_URL` is origin-only — do **not** fold the prefix into the env var (see [`local-dev/hermetic-stack.md`](local-dev/hermetic-stack.md#browser-vs-container-urls)).
+
+**Dev loop**: either let `docker compose up` serve the frontend preview build at `:4173`, or run Vite dev mode standalone for faster HMR against the backend at `:3000`:
+
+```bash
+cd apps/frontend
+bun install
+bun run dev
+```
+
+Keep `docker compose up backend firebase-emulator minio …` running alongside so the dev server has something to talk to.
+
+---
+
+## Backend
+
+Rust axum HTTP server at `apps/backend/`.
+
+- **Stack**: axum + tokio, Firebase admin SDK (`firebase-auth` crate) for ID-token verification, `aws-sdk-s3` + `aws-sdk-sesv2`, `kube` for the orchestrator.
+- **Route namespaces**:
+  - `/api/v1/*` — public, auth-gated endpoints (upload, contribute, assistant, files, cycles, video-edit)
+  - `/api/internal/*` — stage callbacks; reachable only from the cluster network
+  - `/healthz` — liveness probe
+- **Auth**: `firebase-auth` crate verifies `Authorization: Bearer <id-token>`. Local dev short-circuits signature verification via `FIREBASE_AUTH_EMULATOR_HOST` — see [`local-dev/hermetic-stack.md`](local-dev/hermetic-stack.md#firebase_auth_emulator_hostfirebase-emulator9099).
+- **Orchestrator gate**: `ENABLE_ORCHESTRATOR=true` spawns the K8s Jobs orchestrator loop in `helper/orchestrator.rs`. **Local dev leaves it unset** (stages self-poll in worker mode). **Prod sets it** (stages run as one-shot K8s Jobs).
+- **Firebase client**: `igait_lib::microservice::FirebaseRtdb` is the only Firebase client in this repo. Don't re-introduce `firebase-rs` — see [`architecture/firebase-client.md`](architecture/firebase-client.md) for the backstory (it broke the hermetic stack).
+
+**Dev loop**: `docker compose up backend` is the default. For a tighter Rust rebuild loop:
+
+```bash
+cd apps/backend
+cargo run --release
+```
+
+…but the surrogates (`firebase-emulator`, `minio`, `ses-mock`, plus the two `-bootstrap` one-shots) still need to be up for anything useful to happen.
+
+---
+
+## Pipeline
+
+The 5 stages live at `apps/stages/`. The shared lib — `StageWorker` trait, queue + storage clients — lives at `apps/shared/` as `igait_lib`.
+
+**The stage pattern** (full tour in [`apps/stages/README.md`](../apps/stages/README.md)):
+
+```rust
+if std::env::var("IGAIT_JOB_PAYLOAD").is_ok() {
+    run_stage_job(Worker).await      // one-shot (prod, K8s Jobs)
+} else {
+    run_stage_worker(Worker).await   // polling (local, long-running)
+}
+```
+
+Finalize uses `IGAIT_FINALIZE_PAYLOAD` because its queue item type is `FinalizeQueueItem`, not `QueueItem`. Otherwise identical.
+
+- **Coordination**: Firebase RTDB. A `QueueItem` at `queues/<stage>/<job>` is the unit of work; whoever claims it first (K8s pod or long-running worker) wins. Deep dive in [`architecture/stage-execution-modes.md`](architecture/stage-execution-modes.md).
+- **I/O**: stages read/write media via MinIO (local) or S3 (prod). `StorageClient` in `igait_lib` handles both. `AWS_S3_FORCE_PATH_STYLE=true` is load-bearing for MinIO — don't drop it.
+- **Tests**: inline `#[cfg(test)]` modules in `apps/shared/src/microservice/`. Integration coverage comes from the hermetic compose stack (CI runs the full upload → pipeline → email path every PR).
+
+**Dev loop**: stages auto-boot under `docker compose up`. After editing a stage's source:
+
+```bash
+docker compose restart <stage-name>
+```
+
+No hot reload — the container rebuilds its Rust binary on restart. First build is slow; subsequent ones are cached aggressively via cargo-chef (see [`infra/docker/workspace/`](../infra/docker/workspace/README.md)).
+
+---
+
+## Infra
+
+K8s manifests at `infra/k8s/`, Dockerfiles at `infra/docker/`, Firebase rules at `infra/firebase/`.
+
+- **Kustomize, not Helm.** Flat structure — no `base/` + `overlays/`, one prod target. Layout + app-of-apps shape: [`infra/k8s/README.md`](../infra/k8s/README.md).
+- **Deploy flow**: push `main` → path-filtered `build-<app>.yml` builds + pushes image → bot auto-commits the new image tag into `infra/k8s/<app>/deployment.yaml` → ArgoCD syncs within seconds. Full diagram and gotchas: [`deployment/deploy-flow.md`](deployment/deploy-flow.md).
+- **Secrets**: AWS SSM Parameter Store (`/igait/prod/*`, us-east-2) → External Secrets Operator → K8s Secrets (`igait-secrets`, `gcp-key`, `operator-oauth`). IAM policy, rotation, Tailscale ACL setup: [`deployment/external-secrets.md`](deployment/external-secrets.md).
+- **Cluster access**: kubectl from your laptop via Tailscale. **SSH is a cardinal sin** — anything kubectl can do should go through kubectl. Bootstrap recipes: [`deployment/cluster.md`](deployment/cluster.md).
+- **No cert-manager, no metrics stack.** Cloudflared tunnel handles external TLS. Logs are the observability surface — rationale in [`local-dev/dev-loop.md`](local-dev/dev-loop.md#observability).
+
+**Dev loop**: there isn't a true iterative loop for infra — changes land through PRs and ArgoCD syncs on merge. For local validation of K8s manifests, `kubectl apply --dry-run=server -k infra/k8s/` catches most syntax/schema issues before pushing.
+
+---
+
+## A note on docs
+
+The docs under `docs/` encode *why* alongside *how* so a future refactor can't silently collapse a load-bearing invariant. If you add or edit a doc, follow that pattern — it's the highest-leverage thing you can do for the person reading it in six months ʕ·ᴥ·ʔ

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,1 +1,62 @@
 # infra/k8s
+
+Kustomize manifests for iGait's prod K8s cluster. Deployed continuously
+by ArgoCD from this folder — no manual `kubectl apply -k` under normal
+conditions.
+
+## Layout
+
+Flat — no `base/` + `overlays/` split, one prod target.
+
+```
+infra/k8s/
+├── kustomization.yaml         # root: bundles namespace + backend + frontend
+├── igait-namespace/           # the `igait` namespace itself
+├── backend/                   # Deployment, Service, RBAC, ExternalSecret
+├── frontend/                  # Deployment, Service
+├── argocd/apps/               # ArgoCD Application CRs (app-of-apps pattern)
+├── cloudflared/               # in-cluster ingress via Cloudflare tunnel
+├── external-secrets/          # External Secrets Operator install
+├── tailscale-operator/        # Tailscale Operator install
+└── vaultwarden/               # team password vault (off the runtime-secret path)
+```
+
+## App-of-apps
+
+ArgoCD bootstraps everything from a single `app-of-apps` Application at
+`argocd/apps/app-of-apps.yaml`, which in turn creates one Application
+per child — `igait` (the root kustomization above), `cloudflared`,
+`vaultwarden`, `tailscale-operator`, `external-secrets`, and
+`nvidia-device-plugin`.
+
+Two pairs run in waves because their manifests depend on secrets ESO
+materializes:
+
+- `external-secrets-config` (wave `-1`) → `external-secrets` (wave `0`)
+- `tailscale-operator-config` (wave `-1`) → `tailscale-operator` (wave `0`)
+
+All Applications have `selfHeal: true` and `prune: true` — drift is
+reverted on the next reconcile, removed resources are deleted.
+
+## How code reaches this folder
+
+Not by hand. Each `build-*.yml` workflow on push to `main` sed-replaces
+the image tag in the matching `*/deployment.yaml` and commits with a
+`deploy:` prefix; ArgoCD picks it up within seconds. See
+[`docs/deployment/deploy-flow.md`](../../docs/deployment/deploy-flow.md)
+for the full pipeline.
+
+CI has `paths-ignore: infra/k8s/**` so those bot commits don't retrigger
+CI — deliberate.
+
+## Related reading
+
+- **Cluster access + kubectl recipes:** [`docs/deployment/cluster.md`](../../docs/deployment/cluster.md)
+- **Secrets (SSM → ESO → K8s):** [`docs/deployment/external-secrets.md`](../../docs/deployment/external-secrets.md)
+- **Deploy flow end-to-end:** [`docs/deployment/deploy-flow.md`](../../docs/deployment/deploy-flow.md)
+
+## Editing
+
+Change manifests in a PR, wait for ArgoCD to sync on merge. Out-of-band
+`kubectl apply` is reserved for emergencies — `selfHeal` will revert
+drift on the next reconcile anyway.


### PR DESCRIPTION
Adds docs/README.md (terse index) and docs/onboarding.md (role-sectioned
narrative: everyone / frontend / backend / pipeline / infra). Bundles
quality gates + observability stance into docs/local-dev/dev-loop.md
and pins the push-->build-->ArgoCD-sync pipeline in
docs/deployment/deploy-flow.md.

Stub-ifies apps/frontend/README.md (was stock Svelte CLI boilerplate
saying npm when the repo uses bun), adds apps/backend/README.md and
apps/stages/README.md stubs pointing at the central docs, and fleshes
out the previously-empty infra/k8s/README.md with the Kustomize +
ArgoCD app-of-apps shape.

Rewrites .claude/CLAUDE.md as invariant bullets (each with the *why*)
instead of prose --- same substance, denser. Shrinks
docs/environment/vaultwarden.md to a deprecation stub, fixes the stale
"moving to AWS Parameter Store soon" line in the root README, and adds
a pointer from the root README's Development section to docs/README.md
so new devs find the role-aware entry point.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>